### PR TITLE
chore: restrict CI and Vercel deployment to main branch only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ develop, main ]
+    branches: [ main ]
   pull_request:
-    branches: [ develop, main ]
+    branches: [ main ]
 
 jobs:
   test:

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,7 @@
 {
+    "git": {
+        "deploymentEnabled": false
+    },
     "buildCommand": "npm run build",
     "outputDirectory": "dist",
     "installCommand": "npm install",


### PR DESCRIPTION
## Summary
- CI workflowをmainブランチへのpush/PRのみで実行するように変更
- Vercel Git統合の自動デプロイを無効化（GitHub Actions経由のみでデプロイ）

## Test plan
- [ ] mainブランチへのPRでCIが実行されることを確認
- [ ] developブランチへのpushでCIが実行されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)