### PR TITLE
feat: アプリアイコン・スプラッシュ画面の設定を追加 (#62)

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -1,28 +1,57 @@
 {
     "cli": {
-        "version": ">= 6.1.0"
+        "version": ">= 6.1.0",
+        "appVersionSource": "remote"
     },
     "build": {
         "development": {
             "developmentClient": true,
             "distribution": "internal",
+            "ios": {
+                "simulator": true
+            },
             "env": {
                 "APP_VARIANT": "development"
             }
         },
         "preview": {
             "distribution": "internal",
+            "ios": {
+                "simulator": false
+            },
+            "android": {
+                "buildType": "apk"
+            },
             "env": {
                 "APP_VARIANT": "preview"
             }
         },
         "production": {
+            "autoIncrement": true,
+            "ios": {
+                "simulator": false,
+                "resourceClass": "m-medium"
+            },
+            "android": {
+                "buildType": "app-bundle",
+                "resourceClass": "m-medium"
+            },
             "env": {
                 "APP_VARIANT": "production"
             }
         }
     },
     "submit": {
-        "production": {}
+        "production": {
+            "ios": {
+                "appleId": "${APPLE_ID}",
+                "ascAppId": "${ASC_APP_ID}",
+                "appleTeamId": "${APPLE_TEAM_ID}"
+            },
+            "android": {
+                "serviceAccountKeyPath": "./google-services-key.json",
+                "track": "internal"
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- アプリアイコンとスプラッシュ画面の設定をapp.jsonに追加
- ストア申請に必要なiOS/Android固有設定を追加
- プレースホルダーのアセットファイルを追加

## 変更内容

### app.json

| 項目 | 設定内容 |
|------|----------|
| アプリ名 | デジタルおみくじ |
| アイコン | ./assets/icon.png |
| スプラッシュ | ./assets/splash.png (背景色: #dc2626) |

### iOS設定

- bundleIdentifier: `com.s977043.digitalomikuji`
- buildNumber: 1
- infoPlist: 写真ライブラリ使用理由の説明

### Android設定

- package: `com.s977043.digitalomikuji`
- versionCode: 1
- adaptiveIcon設定
- ストレージパーミッション

### アセットファイル

- `assets/splash.png` - スプラッシュ画面用（プレースホルダー）
- `assets/adaptive-icon.png` - Android用（プレースホルダー）
- `assets/favicon.png` - Web用（プレースホルダー）

## 注意事項

⚠️ 現在のアセットファイルはプレースホルダーです。
本番リリース前に正式なデザインに差し替えてください。

## Test plan

- [x] app.json の構文確認
- [ ] アセットファイルの表示確認
- [ ] `npx expo start` でアプリ起動確認

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)