### PR TITLE
fix: use env block for VERCEL_TOKEN instead of inline secrets

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -16,6 +16,7 @@ jobs:
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -29,11 +30,11 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: Pull Vercel Project Information
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=production --token=$VERCEL_TOKEN
 
       - name: Build Project Artifacts
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --prod --token=$VERCEL_TOKEN
 
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} --prod
+        run: vercel deploy --prebuilt --token=$VERCEL_TOKEN --prod
 


### PR DESCRIPTION
## Summary

- VERCEL_TOKENをenvブロックで定義し、runコマンドでは環境変数として参照

## 背景

River Reviewerの指摘:
> runブロック内でsecretsを直接使用している
> ログ出力やエラーメッセージでシークレットが漏洩する可能性

## 変更内容

```diff
env:
  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+ VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

- run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+ run: vercel pull --yes --environment=production --token=$VERCEL_TOKEN
```

## Test plan

- [ ] CIが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)