### PR TITLE
[fix] Pin pnpm と Node.js のバージョンを明示

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+node-linker=hoisted
+symlink=false

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,26 +1,25 @@
 Goal (成功条件を含む):
-- Issue #80 ([Epic]AGENTS.md を共通指示の単一ソースにして各エージェントから参照) の完了条件達成：共通 AGENTS.md と各エージェント用薄いラッパー/参照ファイルを整備し、運用方針を満たす。
+- Vercel ビルドで発生する `ERR_INVALID_THIS`（fetch/URLSearchParams 互換性問題）を解消し、推奨設定（pnpm/Node 指定、必要ならロック再生成・npmrc 調整）を反映してビルドが通る状態にする。
 
 Constraints / Assumptions:
 - 共通ルールはリポジトリ直下の `AGENTS.md`（pnpm 前提、ロックファイル/`.env*` 不触等）を正とする。
 - 開発者指示：現在のブランチでコミットし、コミット後に `make_pr` で PR を作成する。
-- ユーザー指示：タスク着手前に計画作成、セルフレビュー実施、PR で Gemini と Codex にレビュー依頼。ブランチはタスク単位で用意する。
-- 受け入れ条件: ルート AGENTS.md 整備、Copilot/Claude/Gemini の薄いラッパー、Codex は AGENTS.md 前提で運用できる状態。
+- 触らない: `node_modules/`, `**/*.lock`, `.env*`, `secrets/`。
+- ビルド環境は Vercel（Node 18/20 系）。pnpm バージョン差分がエラー要因の可能性。
 
 Key decisions:
-- 共通 `AGENTS.md` をリポジトリ直下に置き、pnpm ベースの開発手順・コーディング規約・PR ルールを一元化する。
-- `.agent/AGENTS.md` は共通ガイドへの参照を主体にし、.agent 配下のメタ情報のみ補足する。
-- エージェント向けファイル（Copilot, Claude, Gemini, Codex）は共通ルールを参照しつつ、ツール固有の要点だけを薄く記載する。
-- ブランチを `work` から派生した `feature/80-agents` に切り替えた。
+- Vercel 環境向けに `packageManager` で pnpm v9 を明示し、`engines.node` で Node 20.x を指定して整合性を図る。
+- ロックファイル再生成の要否は状況を見て判断し、実施する場合は理由と手順を明示する。
+- レポジトリ方針に従いロックファイルは変更せず現状を維持する。
 
 State:
-  - Done: ルート `AGENTS.md` 追加、`.agent/AGENTS.md` を補足的な参照に変更、Codex/Claude/Copilot 向けファイル更新、`GEMINI.md` 新規追加、ブランチを `feature/80-agents` に切替。
-  - Now: 受け入れ条件のセルフチェック中。`pnpm test` を実行したが、`@react-native/js-polyfills/error-guard.js` の型注釈に起因する Jest パースエラーで失敗したことを確認。
-  - Next: テスト失敗を共有しつつセルフレビューを完了させ、コミット・PR 準備。
+  - Done: ビルドエラーレポートと対処方針の確認。`package.json` に Node/pnpm の指定を追加。`.npmrc` を追加。`pnpm test` を実行（Jest は React Native polyfill の型注釈で失敗）。変更をコミットし PR を作成。
+  - Now: レビュー待ち。
+  - Next: フィードバック対応（必要に応じて）。
 
 Open questions（必要なら UNCONFIRMED）:
-- 現時点で未解決の質問なし。
+- UNCONFIRMED: 現行 `pnpm-lock.yaml` を保持したまま修正で解消するか、再生成が必須か未確認。
 
 Working set（files / ids / commands）:
-- ファイル: `.github/copilot-instructions.md`, `codex.md`, `.agent/CLAUDE.md`, `.agent/AGENTS.md`, `AGENTS.md`, `GEMINI.md`, `CONTINUITY.md`
-- コマンド: `curl -s https://api.github.com/repos/s977043/digital-omikuji/issues/80`, `cat .github/copilot-instructions.md`, `cat codex.md`, `cat .agent/CLAUDE.md`, `git checkout -b feature/80-agents`, `pnpm test`
+- ファイル: `package.json`, `.npmrc`, `CONTINUITY.md`
+- コマンド: `cat AGENTS.md`, `cat CONTINUITY.md`, `pnpm test`, `git status --short`, `git commit`

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.1",
   "main": "expo-router/entry",
   "engines": {
-    "node": ">=20.0.0"
+    "node": "20.x"
   },
+  "packageManager": "pnpm@9.15.2",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",


### PR DESCRIPTION
## 目的
- Vercel ビルドで発生している `ERR_INVALID_THIS` の解消に向け、Node.js と pnpm のバージョンをビルド環境で固定する。

## 変更点
- `package.json` に `packageManager` を追加し、pnpm v9.15.2 を明示。
- `engines.node` を 20.x に固定して Vercel 環境と整合させる。
- `.npmrc` を追加し、`node-linker=hoisted` と `symlink=false` を設定。
- `CONTINUITY.md` を今回の作業内容とテスト結果で更新。

## テスト結果ログ
- `pnpm test` : 失敗（`@react-native/js-polyfills/error-guard.js` の Flow 型注釈を Jest がパースできず停止）

## 影響範囲
- Vercel ビルド環境で使用される Node.js / pnpm のバージョン
- pnpm の依存解決方法（hoisted モード、シンボリックリンク無効化）
- 継続性台帳の記載内容

## スクリーンショット / 動画
- なし

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695653c98434832aafbe54665d3a64d9)