### PR TITLE
[fix] Androidビルド修正: workletsの自動リンク無効化

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -2,7 +2,7 @@ module.exports = {
   dependencies: {
     'react-native-worklets-core': {
       platforms: {
-        android: null, // Disable autolinking on Android to avoid build errors with RN 0.76+
+        android: null, // Disable autolinking on Android to avoid build errors with RN 0.76
         ios: null,     // Disable autolinking on iOS as well
       },
     },


### PR DESCRIPTION
## 概要
eact-native-worklets がReact Native 0.76系と互換性がないため、Androidビルド時にGradleエラーが発生していました。
Web版ではNativeWindのビルドに必須であるためパッケージ自体は削除できません。
そのため、eact-native.config.js を追加し、Android（およびiOS）において自動リンクを無効化することで回避します。

## 変更内容
- eact-native.config.js の追加
  - eact-native-worklets の platforms.android および platforms.ios を 
ull (無効) に設定

## 確認事項
- Androidビルド (EAS) が通ること
- Web版の動作に影響がないこと（ビルド時のみの使用であるため影響はないはず）