### PR TITLE
fix: update Vercel header source patterns for CLI compatibility

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -19,7 +19,7 @@
     ],
     "headers": [
         {
-            "source": "/((assets|fonts|_expo)/.*|.*\\.(js|css|woff|woff2|ttf|otf|eot))",
+            "source": "/(assets|fonts|_expo)/:path*",
             "headers": [
                 {
                     "key": "Cache-Control",
@@ -28,7 +28,7 @@
             ]
         },
         {
-            "source": "/(.*\\.(png|jpg|jpeg|gif|webp|avif|svg|ico))",
+            "source": "/(.*).:ext(png|jpg|jpeg|gif|webp|avif|svg|ico)",
             "headers": [
                 {
                     "key": "Cache-Control",
@@ -37,7 +37,7 @@
             ]
         },
         {
-            "source": "/(.*\\.(mp3|wav|ogg|m4a))",
+            "source": "/(.*).:ext(mp3|wav|ogg|m4a)",
             "headers": [
                 {
                     "key": "Cache-Control",
@@ -46,7 +46,7 @@
             ]
         },
         {
-            "source": "/(.*\\.html)",
+            "source": "/(.*).:ext(html)",
             "headers": [
                 {
                     "key": "Cache-Control",


### PR DESCRIPTION
## 目的
Vercel CLI でのビルドエラーを修正します。

## 問題
`vercel.json` の `headers` セクションにある正規表現パターンが Vercel CLI でサポートされていない形式でした。

```
Error: Header at index 0 has invalid `source` pattern
```

## 変更点
正規表現パターンを path-to-regexp 互換形式に変更:
- 複雑な正規表現 → シンプルなパス形式

## 動作確認
- デプロイワークフローでのビルド成功を確認