### PR TITLE
feat: Xシェア文言テンプレート最適化 (#132)

### DIFF
--- a/components/ResultScrollCard.tsx
+++ b/components/ResultScrollCard.tsx
@@ -5,6 +5,7 @@ import { OmikujiResult } from "../types/omikuji";
 import { captureRef } from "react-native-view-shot";
 import * as Haptics from "expo-haptics";
 import { Ionicons } from "@expo/vector-icons";
+import { buildShareText } from "../utils/buildShareText";
 
 interface ResultScrollCardProps {
   fortune: OmikujiResult;
@@ -21,7 +22,7 @@ export const ResultScrollCard = ({ fortune, onReset }: ResultScrollCardProps) =>
         await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
       }
 
-      const message = `🎍 2026年 新春おみくじ 🎍\n\n私の運勢は… ✨ ${fortune.fortuneParams.title} ✨\n「${fortune.fortuneParams.description}」\n\n#おみくじ2026 #新春`;
+      const message = buildShareText(fortune);
 
       // Capture logic
       let imageUri: string | undefined;

--- a/components/__tests__/FortuneDisplay.test.tsx
+++ b/components/__tests__/FortuneDisplay.test.tsx
@@ -115,6 +115,12 @@ describe("FortuneDisplay", () => {
         }),
         expect.any(Object)
       );
+      expect(Share.share).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("#エンジニアおみくじ2026"),
+        }),
+        expect.any(Object)
+      );
     });
 
     // Unlock transition might take time, or React state update happens.

--- a/utils/__tests__/buildShareText.test.ts
+++ b/utils/__tests__/buildShareText.test.ts
@@ -1,0 +1,38 @@
+import { buildShareText } from "../buildShareText";
+import { OmikujiResult } from "../../types/omikuji";
+
+describe("buildShareText", () => {
+  const mockFortune: OmikujiResult = {
+    id: "test",
+    level: "daikichi",
+    fortuneParams: {
+      title: "大吉",
+      description: "Awesome description",
+    },
+    image: { uri: "test" },
+    color: "#000",
+    createdAt: 1234567890,
+  };
+
+  it("generates correct share text", () => {
+    const text = buildShareText(mockFortune);
+
+    expect(text).toContain("2026年のエンジニア運勢は");
+    expect(text).toContain("『大吉』");
+    expect(text).toContain("#エンジニアおみくじ2026");
+    expect(text).toContain("#令和七年");
+    expect(text).toContain("あなたも占ってみよう👇");
+    expect(text).toContain(
+      "https://digital-omikuji-app.vercel.app?utm_source=share&utm_campaign=omikuji2026"
+    );
+  });
+
+  it("handles different fortune titles", () => {
+    const kyoFortune = {
+      ...mockFortune,
+      fortuneParams: { title: "凶", description: "Bad luck" },
+    };
+    const text = buildShareText(kyoFortune as OmikujiResult);
+    expect(text).toContain("『凶』");
+  });
+});

--- a/utils/buildShareText.ts
+++ b/utils/buildShareText.ts
@@ -1,0 +1,24 @@
+import { OmikujiResult } from "../types/omikuji";
+
+const APP_URL = "https://digital-omikuji-app.vercel.app"; // Replace with actual URL if different
+const HASHTAGS = ["#エンジニアおみくじ2026", "#令和七年"];
+
+/**
+ * Builds the share text for X (Twitter).
+ *
+ * Template:
+ * 2026年のエンジニア運勢は
+ * 『{運勢}』
+ *
+ * #エンジニアおみくじ2026
+ * #令和七年
+ *
+ * あなたも占ってみよう👇
+ * {URL}
+ */
+export function buildShareText(fortune: OmikujiResult): string {
+  const hashtags = HASHTAGS.join("\n");
+  const url = `${APP_URL}?utm_source=share&utm_campaign=omikuji2026`;
+
+  return `2026年のエンジニア運勢は\n『${fortune.fortuneParams.title}』\n\n${hashtags}\n\nあなたも占ってみよう👇\n${url}`;
+}


### PR DESCRIPTION
### 概要
Issue 3: Xシェア文言テンプレを最適化（結果先頭・改行・タグ・CTA）の実装。

### 変更点
- `utils/buildShareText.ts` を作成し、シェア文言生成ロジックを一元化
- `ResultScrollCard.tsx` で上記ユーティリティを使用
- URLに計測パラメータを付与 (`?utm_source=share&utm_campaign=omikuji2026`)
- ユニットテスト追加