### PR TITLE
fix: sync app version to 1.1.0 for Sentry release tracking (Issue #170)

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
     "expo": {
         "name": "デジタルおみくじ",
         "slug": "digital-omikuji",
-        "version": "1.0.0",
+        "version": "1.1.0",
         "orientation": "portrait",
         "userInterfaceStyle": "light",
         "icon": "./assets/icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digital-omikuji",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "expo-router/entry",
   "engines": {
     "node": "20.x"


### PR DESCRIPTION
Resolves #170

## 目的
Sentryログと製品バージョンの不一致を解消するため、 および  のバージョンをリリース  に合わせます。

## 変更点
- : `1.0.0` -> `1.1.0`
- : `1.0.0` -> `1.1.0`

## テスト結果
`pnpm test` passed.
- Test Suites: 12 passed, 12 total
- Tests: 1 skipped, 57 passed, 58 total

## 影響範囲
- SentryのRelease名が `digital-omikuji@1.1.0` に変更されます。
- `Constants.expoConfig.version` を参照している箇所の値が変わります（バージョン表示など）。