### PR TITLE
feat: implement Image Card sharing (Issue #186)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "expo-sensors": "~14.0.2",
     "expo-splash-screen": "~0.29.24",
     "expo-status-bar": "~2.0.1",
+    "html-to-image": "^1.11.13",
     "i18next": "^25.7.4",
     "moti": "^0.30.0",
     "nativewind": "^4.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       expo-status-bar:
         specifier: ~2.0.1
         version: 2.0.1(react-native@0.76.9(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       i18next:
         specifier: ^25.7.4
         version: 25.7.4(typescript@5.9.3)
@@ -3723,6 +3726,9 @@ packages:
 
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   html2canvas@1.4.1:
     resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
@@ -11502,6 +11508,8 @@ snapshots:
   html-parse-stringify@3.0.1:
     dependencies:
       void-elements: 3.1.0
+
+  html-to-image@1.11.13: {}
 
   html2canvas@1.4.1:
     dependencies:


### PR DESCRIPTION
Closes #186

## 概要
おみくじ結果を画像カードとしてSNS等にシェアできる機能を実装しました。

## 実装内容
- **Web対応**: `html-to-image` を使用してDOMから画像を生成し、Web Share API (Level 2) で画像共有が可能になりました。非対応ブラウザではダウンロードとしてフォールバックします。
- **Native対応**: `react-native-view-shot` を活用した画像生成を継続しつつ、シェア対象を「アクションボタンを除いたカード部分」に限定するようレイアウトを最適化しました。
- **UI調整**: シェア用画像にフッターの操作ボタンが含まれないよう、キャプチャ用のラッパーを分離しました。

## 検証
- `pnpm test` パス済み。
- Web/Native 両環境での条件分岐ロジックを実装済み。

## 依存関係
- `html-to-image` を追加しました。