### PR TITLE
[feat] Add AI Review Skills (Codex, Gemini, Copilot)

### DIFF
--- a/.agent/skills/codex-review/SKILL.md
+++ b/.agent/skills/codex-review/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: codex-review
+description: Codex CLIを使ったレビュー依頼。tmux経由でcodexコマンドを操作し、ファイルや出力をレビューさせる。
+---
+# Codex Review (Optimized for Digital Omikuji)
+
+OpenAI Codex CLI（`codex`コマンド）とtmux経由で連携し、**Digital Omikuji プロジェクトのコンテキスト（Expo/NativeWind/Japanese）を踏まえたレビュー**を実行します。
+
+**重要**: 「Codex」= Codex CLIツール（ターミナルコマンド）
+
+## Prerequisites
+
+- `tmux` セッション `dev` が起動していること（`dev` コマンドで起動）。
+- ペイン `dev:0.1` に `codex` CLI が待機していること。
+
+## Usage (推奨: スクリプト経由)
+
+付属のスクリプトを使用すると、自動的にプロジェクトコンテキスト（Expo SDK 54, Router v4, etc.）がプロンプトに注入されます。
+
+### ファイルをレビューする場合
+
+```bash
+# 相対パスまたは絶対パスを指定
+bash .agent/skills/codex-review/review.sh path/to/file.tsx
+```
+
+### 直前の出力や任意の内容をレビューする場合
+
+```bash
+# パイプで渡す
+echo "..." | bash .agent/skills/codex-review/review.sh
+
+# または git diff を渡す
+git diff | bash .agent/skills/codex-review/review.sh
+```
+
+## Manual Instructions (Fallback)
+
+スクリプトが使えない場合の基本コマンド（Context注入なし）。
+
+### 基本コマンド（macOS互換）
+
+応答を待機して取得する:
+
+```bash
+tmux clear-history -t dev:0.1 && \
+tmux send-keys -t dev:0.1 "内容をここに" && \
+tmux send-keys -t dev:0.1 C-m && \
+for i in {1..60}; do
+  if tmux capture-pane -t dev:0.1 -p | grep -q "^›"; then break; fi
+  sleep 1
+done && \
+tmux capture-pane -t dev:0.1 -p -S -100
+```
+
+### tmuxペイン構成
+
+```
+┌─────────────┬─────────────┐
+│ 0: Claude   │ 1: Codex    │  ← dev:0.1
+└─────────────┴─────────────┘
+```

--- a/.agent/skills/codex-review/review.sh
+++ b/.agent/skills/codex-review/review.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -e
+
+# Configuration
+PANE_TARGET="dev:0.1"
+TIMEOUT_SECONDS=60
+CONTEXT_PROMPT="[Context: Expo SDK 54, Router v4, NativeWind v4, Japanese Language, AGENTS.md rules]"
+
+# Function to run tmux commands
+run_review() {
+    local input_text="$1"
+    
+    # Check tmux session
+    if ! tmux has-session -t "${PANE_TARGET%%:*}" 2>/dev/null; then
+        echo "Error: tmux session '${PANE_TARGET%%:*}' not found."
+        echo "Please start the dev environment with 'dev' command."
+        exit 1
+    fi
+
+    # Clear history
+    tmux clear-history -t "$PANE_TARGET"
+
+    # Send input
+    tmux send-keys -t "$PANE_TARGET" "$input_text" C-m
+
+    # Wait for response (detected by prompt '›')
+    local waiting=true
+    local counter=0
+    
+    echo "Waiting for Codex response..." >&2
+    
+    while [ $counter -lt $TIMEOUT_SECONDS ]; do
+        if tmux capture-pane -t "$PANE_TARGET" -p | grep -q "^›"; then
+            waiting=false
+            break
+        fi
+        sleep 1
+        counter=$((counter + 1))
+    done
+
+    if [ "$waiting" = true ]; then
+        echo "Timeout waiting for Codex response." >&2
+        return 1
+    fi
+
+    # Capture and output result (last 100 lines)
+    tmux capture-pane -t "$PANE_TARGET" -p -S -100
+}
+
+# Main logic
+if [ -n "$1" ]; then
+    # File mode
+    FILEPATH="$1"
+    if [ ! -f "$FILEPATH" ]; then
+        echo "Error: File $FILEPATH not found."
+        exit 1
+    fi
+    # Use relative path if possible for cleaner prompt
+    RELPATH=$(realpath --relative-to="$(pwd)" "$FILEPATH")
+    PROMPT="${CONTEXT_PROMPT} ${RELPATH} をレビューして。コードの品質、バグ、保守性、およびAGENTS.mdの規約違反について指摘してください。"
+    run_review "$PROMPT"
+else
+    # Stdin/Direct mode (read from stdin if available, otherwise usage)
+    if [ -p /dev/stdin ]; then
+        CONTENT=$(cat)
+        PROMPT="${CONTEXT_PROMPT} 以下のコード/内容をレビューして：\n\n${CONTENT}"
+        run_review "$PROMPT"
+    else
+        echo "Usage: $0 <file>"
+        echo "       cat content | $0"
+        exit 1
+    fi
+fi

--- a/.agent/skills/copilot-review/SKILL.md
+++ b/.agent/skills/copilot-review/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: copilot-review
+description: GitHub Copilot CLI (`copilot`) を使ったレビュー依頼。
+---
+# Copilot Review
+
+GitHub Copilot CLI (`copilot` コマンド) を使用してレビューを行います。
+
+## Prerequisites
+
+- `copilot` コマンドがパスに通っていること。
+- `gh auth login` 等で認証済みであること。
+
+## Usage
+
+付属のスクリプトを使用すると、ファイルパス指定で簡単にレビューを依頼できます。スクリプトは `copilot` コマンドを非対話モード (`-p`) で呼び出します。
+
+### ファイルをレビューする場合
+
+```bash
+bash .agent/skills/copilot-review/review.sh path/to/file.tsx
+```
+
+### 任意の内容をレビューする場合 (標準入力)
+
+```bash
+echo "func main() {}" | bash .agent/skills/copilot-review/review.sh
+```

--- a/.agent/skills/copilot-review/review.sh
+++ b/.agent/skills/copilot-review/review.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+# Configuration
+CONTEXT_PROMPT="[Context: Expo SDK 54, Router v4, NativeWind v4, Japanese Language, AGENTS.md rules]"
+
+# Main logic
+if [ -n "$1" ]; then
+    # File mode
+    FILEPATH="$1"
+    if [ ! -f "$FILEPATH" ]; then
+        echo "Error: File $FILEPATH not found."
+        exit 1
+    fi
+    RELPATH=$(realpath --relative-to="$(pwd)" "$FILEPATH")
+    ABS_PATH=$(realpath "$FILEPATH")
+    
+    # We ask copilot to read the file explicitly if support tool usage, but here passing content in prompt is safer for 'explain' style if supported.
+    # However, copilot CLI usually can read files if instructed.
+    # Let's try constructing a prompt telling it to review the file at the path.
+    
+    PROMPT="${CONTEXT_PROMPT} Review the file at ${ABS_PATH}. Checking for quality, bugs, maintainability, and AGENTS.md violations."
+    
+    # Execute
+    copilot -p "$PROMPT" --allow-all-paths
+
+else
+    # Stdin mode
+    if [ -p /dev/stdin ]; then
+        CONTENT=$(cat)
+        PROMPT="${CONTEXT_PROMPT} Review the following code:\n\n${CONTENT}"
+        copilot -p "$PROMPT"
+    else
+        echo "Usage: $0 <file>"
+        echo "       cat content | $0"
+        exit 1
+    fi
+fi

--- a/.agent/skills/gemini-review/SKILL.md
+++ b/.agent/skills/gemini-review/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: gemini-review
+description: Gemini CLIを使ったレビュー依頼。
+---
+# Gemini Review
+
+Gemini CLI (`gemini`) を使用してコードレビューを行います。
+
+## Prerequisites
+
+- `gemini` コマンドがパスに通っていること。
+
+## Usage
+
+付属のスクリプトを使用することで、プロジェクトのコンテキスト（Expo/NativeWind/Japanese）が自動的に注入されます。
+
+### ファイルをレビューする場合
+
+```bash
+bash .agent/skills/gemini-review/review.sh path/to/file.tsx
+```
+
+### 任意の内容をレビューする場合
+
+```bash
+echo "内容" | bash .agent/skills/gemini-review/review.sh
+```

--- a/.agent/skills/gemini-review/review.sh
+++ b/.agent/skills/gemini-review/review.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+# Configuration
+CONTEXT_PROMPT="[Context: Expo SDK 54, Router v4, NativeWind v4, Japanese Language, AGENTS.md rules]"
+
+# Main logic
+if [ -n "$1" ]; then
+    # File mode
+    FILEPATH="$1"
+    if [ ! -f "$FILEPATH" ]; then
+        echo "Error: File $FILEPATH not found."
+        exit 1
+    fi
+    # Use relative path if possible
+    RELPATH=$(realpath --relative-to="$(pwd)" "$FILEPATH")
+    
+    # Construct prompt and pipe to gemini
+    # Note: gemini acts as a REPL receiving stdin, so we send the prompt and close stdin.
+    (
+        echo "${CONTEXT_PROMPT}"
+        echo "${RELPATH} をレビューして。コードの品質、バグ、保守性、およびAGENTS.mdの規約違反について指摘してください。"
+        echo "File Content:"
+        cat "$FILEPATH"
+    ) | gemini
+
+else
+    # Stdin mode
+    if [ -p /dev/stdin ]; then
+        (
+            echo "${CONTEXT_PROMPT}"
+            echo "以下のコード/内容をレビューして："
+            cat
+        ) | gemini
+    else
+        echo "Usage: $0 <file>"
+        echo "       cat content | $0"
+        exit 1
+    fi
+fi

--- a/.agent/skills/index.json
+++ b/.agent/skills/index.json
@@ -166,6 +166,61 @@
         "expo"
       ],
       "last_updated": "2026-01-17"
+    },
+    {
+      "id": "codex-review",
+      "name": "codex-review",
+      "description": "Codex CLIを使ったレビュー依頼。tmux経由でcodexコマンドを操作し、ファイルや出力をレビューさせる。",
+      "skill_path": "skills/codex-review/SKILL.md",
+      "contexts": [
+        "Codex",
+        "Gemini",
+        "Antigravity",
+        "Claude"
+      ],
+      "tags": [
+        "codex",
+        "review",
+        "tmux",
+        "cli"
+      ],
+      "last_updated": "2026-01-18"
+    },
+    {
+      "id": "gemini-review",
+      "name": "gemini-review",
+      "description": "Gemini CLIを使ったレビュー依頼。",
+      "skill_path": "skills/gemini-review/SKILL.md",
+      "contexts": [
+        "Codex",
+        "Gemini",
+        "Antigravity",
+        "Claude"
+      ],
+      "tags": [
+        "gemini",
+        "review",
+        "cli"
+      ],
+      "last_updated": "2026-01-18"
+    },
+    {
+      "id": "copilot-review",
+      "name": "copilot-review",
+      "description": "GitHub Copilot CLI (`copilot`) を使ったレビュー依頼。",
+      "skill_path": "skills/copilot-review/SKILL.md",
+      "contexts": [
+        "Codex",
+        "Gemini",
+        "Antigravity",
+        "Claude"
+      ],
+      "tags": [
+        "copilot",
+        "review",
+        "cli"
+      ],
+      "last_updated": "2026-01-18"
     }
   ]
 }


### PR DESCRIPTION
## 目的
Codex, Gemini, GitHub Copilot (CLI) の各エージェントに対し、プロジェクトのコンテキスト（Expo/NativeWind/Japanese）を注入した状態でコードレビューを依頼するための標準スキルを追加しました。

## 変更点

### 新規スキル追加 (.agent/skills/)
1. **codex-review**: Codex CLI + tmux 連携
2. **gemini-review**: Gemini CLI 連携
3. **copilot-review**: GitHub Copilot CLI 連携

### 共通仕様
- 各スキルに `review.sh` ヘルパースクリプトを同梱
- Expo SDK 54, Router v4, NativeWind v4, 日本語等のコンテキストをプロンプトへ自動注入
- `bash .agent/skills/<skill>/review.sh <file>` で実行可能

## 影響範囲
- エージェントの設定ファイルのみ（アプリコードへの変更なし）

## テスト結果
- 手元で各 CLI コマンドの呼び出しとスクリプト経由でのコンテキスト注入を確認済み。
