### PR TITLE
[docs] 開発OS導入ガイドとエージェント運用整理

### DIFF
--- a/.agent/agents/README.md
+++ b/.agent/agents/README.md
@@ -4,20 +4,33 @@
 
 ## 📁 ペルソナ一覧
 
+### 計画・調整
+
+- **[project-planner.md](./project-planner.md)** - 計画立案・タスク分解
+- **[orchestrator.md](./orchestrator.md)** - 複数エージェントの調整
+- **[explorer-agent.md](./explorer-agent.md)** - リポジトリ調査
+- **[database-architect.md](./database-architect.md)** - DB設計・最適化
+
 ### 開発系
 
-- **[digital-omikuji-dev.md](./digital-omikuji-dev.md)** - Digital Omikuji専門の開発エージェント
-- **[feature-generator.md](./feature-generator.md)** - 新機能の自動生成エージェント
-- **[ui-component-generator.md](./ui-component-generator.md)** - UIコンポーネント生成エージェント
-- **[test.md](./test.md)** - テスト専門エージェント
+- **[frontend-specialist.md](./frontend-specialist.md)** - UI/フロントエンド実装
+- **[backend-specialist.md](./backend-specialist.md)** - API/バックエンド実装
+- **[mobile-developer.md](./mobile-developer.md)** - モバイル実装
+- **[game-developer.md](./game-developer.md)** - ゲームロジック実装
 
-### 保守・管理系
+### 品質・テスト・セキュリティ
 
-- **[repo-maintainer.md](./repo-maintainer.md)** - リポジトリ保守エージェント
-- **[documentation-manager.md](./documentation-manager.md)** - ドキュメント管理エージェント
-- **[pr-manager.md](./pr-manager.md)** - PR管理エージェント
-- **[refactor.md](./refactor.md)** - リファクタリング専門エージェント
-- **[security-manager.md](./security-manager.md)** - セキュリティ監視エージェント
+- **[test-engineer.md](./test-engineer.md)** - テスト設計・実装
+- **[debugger.md](./debugger.md)** - 不具合解析
+- **[performance-optimizer.md](./performance-optimizer.md)** - 性能改善
+- **[security-auditor.md](./security-auditor.md)** - セキュリティ監査
+- **[penetration-tester.md](./penetration-tester.md)** - 攻撃観点の検証
+
+### 運用・ドキュメント・SEO
+
+- **[devops-engineer.md](./devops-engineer.md)** - CI/CD・運用
+- **[documentation-writer.md](./documentation-writer.md)** - ドキュメント作成
+- **[seo-specialist.md](./seo-specialist.md)** - SEO/可視性改善
 
 ---
 
@@ -29,12 +42,12 @@
 
 **例**: 新機能開発時
 ```
-feature-generatorペルソナに従って、ログイン機能を実装してください
+project-plannerペルソナに従って、ログイン機能の計画を作成してください
 ```
 
-**例**: リファクタリング時
+**例**: 不具合調査時
 ```
-refactorペルソナの指針に基づいて、components/ディレクトリを整理してください
+debuggerペルソナの指針に基づいて、クラッシュ原因を調査してください
 ```
 
 ### ペルソナとエージェントの違い
@@ -42,14 +55,14 @@ refactorペルソナの指針に基づいて、components/ディレクトリを�
 | 概念 | 説明 | 例 |
 |------|------|-----|
 | **エージェント** | ツール・プラットフォーム | Claude, Copilot, Codex, Gemini, Antigravity |
-| **ペルソナ** | 特定の役割・タスクに特化した振る舞い定義 | feature-generator, test, security-manager |
+| **ペルソナ** | 特定の役割・タスクに特化した振る舞い定義 | project-planner, test-engineer, security-auditor |
 
 **ポイント**: 同じエージェント（例: Claude）でも、異なるペルソナを適用することで振る舞いを変えられます。
 
 **例**:
-- Claude + feature-generator ペルソナ → 新機能開発に特化
-- Claude + test ペルソナ → テスト作成に特化
-- Claude + security-manager ペルソナ → セキュリティレビューに特化
+- Claude + project-planner ペルソナ → 計画立案に特化
+- Claude + test-engineer ペルソナ → テスト作成に特化
+- Claude + security-auditor ペルソナ → セキュリティレビューに特化
 
 ---
 
@@ -86,22 +99,23 @@ refactorペルソナの指針に基づいて、components/ディレクトリを�
 - **[.agent/skills/](../skills/)** - 再利用可能なスキル集
 - **[.agent/steering/](../steering/)** - プロジェクト方針・プロセス定義
 - **[.agent/workflows/](../workflows/)** - 開発ワークフロー集
-- **[.agent/config/unified-agent-config.json](../config/unified-agent-config.json)** - 統一エージェント設定
+- **[.agent/ARCHITECTURE.md](../ARCHITECTURE.md)** - エージェント/スキル構成の概要
 
 ---
 
 ## 💡 ペルソナ活用のヒント
 
 ### 1. タスクに応じてペルソナを切り替える
-- 新機能開発 → `feature-generator`
-- バグ修正 → `digital-omikuji-dev`
-- テスト作成 → `test`
-- リファクタリング → `refactor`
-- セキュリティ確認 → `security-manager`
+- 計画立案 → `project-planner`
+- UI実装 → `frontend-specialist`
+- バグ修正 → `debugger`
+- テスト作成 → `test-engineer`
+- セキュリティ確認 → `security-auditor`
+- 性能改善 → `performance-optimizer`
 
 ### 2. ペルソナを組み合わせる
 ```
-feature-generatorペルソナで実装し、testペルソナでテストを作成してください
+project-plannerペルソナで計画し、test-engineerペルソナでテストを作成してください
 ```
 
 ### 3. カスタムペルソナを作成

--- a/.agent/steering/development.md
+++ b/.agent/steering/development.md
@@ -1,0 +1,67 @@
+---
+title: "開発OS導入ガイド"
+description: "AIエージェント運用を開発OSとして導入するための設計と運用手順"
+version: "1.0"
+last_updated: "2026-01-20"
+target_audience: ["developer", "ai_agent"]
+---
+
+# 開発OS導入ガイド
+
+## 目的
+
+設定の寄せ集めではなく、運用ルール + 自動化 + 安全装置をまとめて「開発OS」として運用する。
+個人設定とプロジェクト設定を分離し、チームの再現性を確保する。
+
+## 3レイヤ構成
+
+- **個人レイヤ (Developer Machine)**: `~/.claude/` など。快適化のみ。チーム必須ルールは置かない。
+- **プロジェクトレイヤ (Repository)**: `AGENTS.md`, `.agent/`, `.claude/`, `.codex/`。前提・禁止事項・標準フローを固定化。
+- **ガバナンスレイヤ (CI / PR)**: `.github/workflows/`, `.github/PULL_REQUEST_TEMPLATE.md`。最終的な強制力を担保。
+
+## 具体的な配置
+
+- **共通ルール**: `AGENTS.md` (SSOT)
+- **Claude**: `CLAUDE.md`, `.claude/settings.json`, `.claude/hooks/`, `.claude/commands/`
+- **Codex**: `.codex/`, `.codex/config.toml`
+- **エージェント定義/スキル**: `.agent/agents/`, `.agent/skills/`
+- **運用フロー**: `.agent/workflows/`, `docs/AI_AGENTS_ROLES.md`
+
+## Hooks の扱い
+
+### 自動化（快適性）
+
+- `PostToolUse` で format/lint/test を補助
+- 例: `.claude/hooks/format.sh`
+
+### 安全装置（ブレーキ）
+
+- `PreToolUse` で危険コマンドや権限要求をブロック
+- 例: `.claude/hooks/safety.sh`
+- Hook は補助。最終的な強制力は CI/PR に置く
+
+## Subagent 運用
+
+- **plan → implement → review → security** を基本フローに固定
+- 役割分担の詳細は `docs/AI_AGENTS_ROLES.md` を参照
+- 複数領域に跨る場合は `orchestrator` で調整する
+
+## MCP は最小構成
+
+- 必須のものだけ有効化
+- 追加は選択式でドキュメント化
+
+## 導入ステップ（推奨順）
+
+1. **快適化Hooks**: format/lint/test を自動化
+2. **プロジェクトルール整備**: SSOT を明確化
+3. **Subagent の工程化**: 役割分担の固定
+4. **安全装置Hooks**: 破壊的操作のブロック
+5. **MCP最小化**: 必要最小限で運用
+
+## 導入済み判定
+
+- PR で format/lint/型の指摘が減っている
+- エージェントが毎回同じ前提で動く
+- 破壊的操作や秘密情報アクセスが Hook/CI で止まる
+- 役割分担が固定化されレビュー品質が安定する

--- a/docs/AI_AGENTS_ROLES.md
+++ b/docs/AI_AGENTS_ROLES.md
@@ -10,25 +10,28 @@
 3. **review**: 差分レビューと改善指摘
 4. **security**: セキュリティ観点の監査
 
-## 役割マッピング（既存定義に接続）
+## 役割マッピング（現行エージェントに接続）
 
 | フェーズ | 主担当エージェント | 期待成果物 | 定義ファイル |
 | --- | --- | --- | --- |
-| plan | feature-generator | `implementation_plan.md` などの計画 / 仕様整理 | `.agent/agents/feature-generator.md` |
-| implement | digital-omikuji-dev | 実装 + テスト追加 | `.agent/agents/digital-omikuji-dev.md` |
-| review | pr-manager | PR 本文の整理 / レビュー依頼 | `.agent/agents/pr-manager.md` |
-| security | security-auditor | 依存関係/コードの安全性チェック | `.agent/agents/security-manager.md` |
+| plan | project-planner | 計画 / タスク分解 | `.agent/agents/project-planner.md` |
+| implement | frontend-specialist / backend-specialist / mobile-developer（必要に応じて orchestrator が調整） | 実装 + テスト追加 | `.agent/agents/frontend-specialist.md`, `.agent/agents/backend-specialist.md`, `.agent/agents/mobile-developer.md`, `.agent/agents/orchestrator.md` |
+| review | test-engineer / debugger | テスト / 品質確認 | `.agent/agents/test-engineer.md`, `.agent/agents/debugger.md` |
+| security | security-auditor | セキュリティ監査 | `.agent/agents/security-auditor.md` |
 
 ## 補助エージェント（必要時）
 
-- **documentation-manager**: ドキュメント更新と整備 (`.agent/agents/documentation-manager.md`)
-- **test-writer**: テスト補強と CI 復旧 (`.agent/agents/test.md`)
-- **refactor-buddy**: 影響を抑えたリファクタ (`.agent/agents/refactor.md`)
-- **ui-component-generator**: UI コンポーネント生成 (`.agent/agents/ui-component-generator.md`)
-- **repo-maintainer**: 依存関係 / CI の保守 (`.agent/agents/repo-maintainer.md`)
+- **documentation-writer**: ドキュメント更新と整備 (`.agent/agents/documentation-writer.md`)
+- **performance-optimizer**: 性能プロファイルと改善 (`.agent/agents/performance-optimizer.md`)
+- **devops-engineer**: CI/CD と運用整備 (`.agent/agents/devops-engineer.md`)
+- **database-architect**: DB 設計や最適化 (`.agent/agents/database-architect.md`)
+- **seo-specialist**: Web の可視性改善 (`.agent/agents/seo-specialist.md`)
+- **penetration-tester**: 攻撃観点の検証 (`.agent/agents/penetration-tester.md`)
+- **explorer-agent**: 既存構成の調査 (`.agent/agents/explorer-agent.md`)
 
 ## 運用ルール（要点）
 
 - plan/implement/review/security を順番に回し、レビューは別エージェントで行う。
-- 変更が大きい場合は plan で合意形成してから implement に進む。
+- 実装は対象領域に応じて `frontend-specialist` / `backend-specialist` / `mobile-developer` を選択する。
+- 複数領域に跨る場合は `orchestrator` で調整する。
 - security は最終工程で、指摘があれば implement に差し戻す。


### PR DESCRIPTION
## 目的

AIエージェント運用を開発OSとして導入するためのガイドを追加し、現行エージェント定義に整合させる。

Fixes # (issue)

## 変更点

- .agent/steering に開発OS導入ガイドを追加
- docs/AI_AGENTS_ROLES.md を現行エージェントに合わせて更新
- .agent/agents/README.md を現行エージェント一覧に更新

## 動作確認（テストログを必ず添付）

- 実行コマンド:
  - `pnpm test`
- ログ:

```text
PASS utils/__tests__/VersionInfo.test.ts
PASS utils/__tests__/HistoryStorage.test.ts
PASS utils/__tests__/SoundManager.test.ts
PASS app/__tests__/privacy-policy.test.tsx
PASS utils/__tests__/omikujiLogic.test.ts
PASS app/__tests__/history.test.tsx
PASS components/__tests__/VersionDisplay.test.tsx
PASS app/__tests__/index.test.tsx
PASS components/__tests__/DrawingOverlay.test.tsx
PASS utils/__tests__/buildShareText.test.ts
PASS components/__tests__/FortuneDisplay.test.tsx
PASS hooks/__tests__/useOmikujiLogic.test.ts (5.562 s)

Test Suites: 12 passed, 12 total
Tests:       1 skipped, 58 passed, 59 total
Snapshots:   0 total
Time:        6.568 s, estimated 68 s
Ran all test suites.
```

## 影響範囲 / リスク

- ドキュメントのみ。実行コード変更なし。

## UI 変更（必要な場合）

- なし

## レビュー依頼（必須）

- [ ] Copilot
- [ ] Gemini
- [ ] Codex

## チェックリスト

- [x] 自己レビュー済み
- [x] 変更は最小差分で、無関係な修正を含まない
- [ ] テストを追加・更新した（必要な場合）
- [x] `pnpm test` が通っている
- [x] ドキュメントを更新した（必要な場合）
