### PR TITLE
[fix] iOS E2EのCallInvokerエラーを回避

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,5 +79,10 @@
     "tailwindcss": "3.4.19",
     "typescript": "^5.9.3"
   },
-  "private": true
+  "private": true,
+  "pnpm": {
+    "patchedDependencies": {
+      "expo-modules-core@3.0.29": "patches/expo-modules-core@3.0.29.patch"
+    }
+  }
 }

--- a/patches/expo-modules-core@3.0.29.patch
+++ b/patches/expo-modules-core@3.0.29.patch
@@ -1,0 +1,15 @@
+diff --git a/ios/JSI/EXJSIUtils.h b/ios/JSI/EXJSIUtils.h
+--- a/ios/JSI/EXJSIUtils.h
++++ b/ios/JSI/EXJSIUtils.h
+@@ -10,6 +10,12 @@
+ #import <ReactCommon/TurboModuleUtils.h>
+ #import <ExpoModulesCore/ObjectDeallocator.h>
+ 
++namespace facebook {
++namespace react {
++class CallInvoker;
++}
++}
++
+ namespace jsi = facebook::jsi;
+ namespace react = facebook::react;

--- a/patches/expo-modules-core@3.0.29.patch
+++ b/patches/expo-modules-core@3.0.29.patch
@@ -2,10 +2,12 @@ diff --git a/ios/JSI/EXJSIUtils.h b/ios/JSI/EXJSIUtils.h
 index 407f57f..e26a36d 100644
 --- a/ios/JSI/EXJSIUtils.h
 +++ b/ios/JSI/EXJSIUtils.h
-@@ -9,6 +9,12 @@
+@@ -9,6 +9,14 @@
  #import <ReactCommon/TurboModuleUtils.h>
  #import <ExpoModulesCore/ObjectDeallocator.h>
  
++// [Digital Omikuji] Workaround: CallInvoker forward declaration for iOS E2E builds.
++// TODO: remove when expo-modules-core includes this upstream.
 +namespace facebook {
 +namespace react {
 +class CallInvoker;

--- a/patches/expo-modules-core@3.0.29.patch
+++ b/patches/expo-modules-core@3.0.29.patch
@@ -1,7 +1,8 @@
 diff --git a/ios/JSI/EXJSIUtils.h b/ios/JSI/EXJSIUtils.h
+index 407f57f..e26a36d 100644
 --- a/ios/JSI/EXJSIUtils.h
 +++ b/ios/JSI/EXJSIUtils.h
-@@ -10,6 +10,12 @@
+@@ -9,6 +9,12 @@
  #import <ReactCommon/TurboModuleUtils.h>
  #import <ExpoModulesCore/ObjectDeallocator.h>
  
@@ -13,3 +14,4 @@ diff --git a/ios/JSI/EXJSIUtils.h b/ios/JSI/EXJSIUtils.h
 +
  namespace jsi = facebook::jsi;
  namespace react = facebook::react;
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   expo-modules-core@3.0.29:
-    hash: 3rtwyaad3lsj7sp6pdrhcdsjtq
+    hash: heza7iyuxzbpmwrunvny57mpga
     path: patches/expo-modules-core@3.0.29.patch
 
 importers:
@@ -10958,7 +10958,7 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
 
-  expo-modules-core@3.0.29(patch_hash=3rtwyaad3lsj7sp6pdrhcdsjtq)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3):
+  expo-modules-core@3.0.29(patch_hash=heza7iyuxzbpmwrunvny57mpga)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3):
     dependencies:
       invariant: 2.2.4
       react: 19.2.3
@@ -11051,7 +11051,7 @@ snapshots:
       expo-font: 14.0.10(expo@54.0.31)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)
       expo-keep-awake: 15.0.8(expo@54.0.31)(react@19.2.3)
       expo-modules-autolinking: 3.0.24
-      expo-modules-core: 3.0.29(patch_hash=3rtwyaad3lsj7sp6pdrhcdsjtq)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)
+      expo-modules-core: 3.0.29(patch_hash=heza7iyuxzbpmwrunvny57mpga)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)
       pretty-format: 29.7.0
       react: 19.2.3
       react-native: 0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  expo-modules-core@3.0.29:
+    hash: 3rtwyaad3lsj7sp6pdrhcdsjtq
+    path: patches/expo-modules-core@3.0.29.patch
+
 importers:
 
   .:
@@ -10953,7 +10958,7 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
 
-  expo-modules-core@3.0.29(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3):
+  expo-modules-core@3.0.29(patch_hash=3rtwyaad3lsj7sp6pdrhcdsjtq)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3):
     dependencies:
       invariant: 2.2.4
       react: 19.2.3
@@ -11046,7 +11051,7 @@ snapshots:
       expo-font: 14.0.10(expo@54.0.31)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)
       expo-keep-awake: 15.0.8(expo@54.0.31)(react@19.2.3)
       expo-modules-autolinking: 3.0.24
-      expo-modules-core: 3.0.29(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)
+      expo-modules-core: 3.0.29(patch_hash=3rtwyaad3lsj7sp6pdrhcdsjtq)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)
       pretty-format: 29.7.0
       react: 19.2.3
       react-native: 0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   expo-modules-core@3.0.29:
-    hash: heza7iyuxzbpmwrunvny57mpga
+    hash: ugjznuzriktq73ws2jskkgq3am
     path: patches/expo-modules-core@3.0.29.patch
 
 importers:
@@ -10958,7 +10958,7 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
 
-  expo-modules-core@3.0.29(patch_hash=heza7iyuxzbpmwrunvny57mpga)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3):
+  expo-modules-core@3.0.29(patch_hash=ugjznuzriktq73ws2jskkgq3am)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3):
     dependencies:
       invariant: 2.2.4
       react: 19.2.3
@@ -11051,7 +11051,7 @@ snapshots:
       expo-font: 14.0.10(expo@54.0.31)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)
       expo-keep-awake: 15.0.8(expo@54.0.31)(react@19.2.3)
       expo-modules-autolinking: 3.0.24
-      expo-modules-core: 3.0.29(patch_hash=heza7iyuxzbpmwrunvny57mpga)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)
+      expo-modules-core: 3.0.29(patch_hash=ugjznuzriktq73ws2jskkgq3am)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)
       pretty-format: 29.7.0
       react: 19.2.3
       react-native: 0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3)


### PR DESCRIPTION
## 目的
iOS E2Eでexpo-modules-coreのCallInvoker未宣言エラーを解消する

## 変更点
- expo-modules-coreにCallInvokerの前方宣言を適用（pnpm patchedDependencies）
- パッチに目的コメントを追加
- pnpm-lock.yamlを更新

## テスト結果ログ
- `pnpm install`

```
WARN Unsupported engine: wanted {"node":"20.x"} (current {"node":"v22.20.0","pnpm":"9.15.2"})
Lockfile is up to date, resolution step is skipped
Packages: +1609
...
Done in 7s
```

## 影響範囲
- 依存パッケージ（expo-modules-core）にパッチ適用
