### PR TITLE
[perf] CIの並列実行とconcurrency追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,24 @@ on:
       - "tailwind.config.js"
       - ".github/workflows/ci.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  # 依存関係のインストールを1回で行い、キャッシュを共有
   ci:
-    name: Type Check, Lint & Test
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Type Check
+            command: pnpm exec tsc --noEmit
+          - name: ESLint
+            command: pnpm lint && pnpm lint:md
+          - name: Tests
+            command: pnpm test
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -65,15 +78,5 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
 
-      # 3つのチェックを順次実行（1回のインストールで済む）
-      - name: Type Check
-        run: pnpm exec tsc --noEmit
-
-      - name: ESLint
-        run: pnpm lint
-
-      - name: Markdown Lint
-        run: pnpm lint:md
-
-      - name: Run Tests
-        run: pnpm test
+      - name: Run
+        run: ${{ matrix.command }}


### PR DESCRIPTION
## 目的
GitHub Actionsの実行時間短縮のため、CIの並列化と無駄な実行の抑制（concurrency）を導入する

## 変更点
- CIをmatrix化してType Check / Lint / Testsを並列実行
- 同一ブランチの重複CIをキャンセルするconcurrencyを追加

## テスト結果ログ
- `pnpm install --frozen-lockfile --prefer-offline`

```
WARN Unsupported engine: wanted {"node":"20.x"} (current {"node":"v22.20.0","pnpm":"9.15.2"})
Lockfile is up to date, resolution step is skipped
Packages: +1609
...
Done in 6.3s
```

- `pnpm lint:md`

```
WARN Unsupported engine: wanted {"node":"20.x"} (current {"node":"v22.20.0","pnpm":"9.15.2"})
> digital-omikuji@1.1.0 lint:md /home/minewo/github/digital-omikuji/.worktrees/ci-actions-opt
> markdownlint .
```

## 影響範囲
- `.github/workflows/ci.yml`
