### PR TITLE
[fix] iOS E2E CallbackWrapperの前方宣言とヘッダー追加

### DIFF
--- a/patches/expo-modules-core@3.0.29.patch
+++ b/patches/expo-modules-core@3.0.29.patch
@@ -4,6 +4,7 @@ index 407f57f..e26a36d 100644
 +++ b/ios/JSI/EXJSIUtils.h
 @@ -9,6 +9,14 @@
  #import <ReactCommon/TurboModuleUtils.h>
++#import <ReactCommon/CallbackWrapper.h>
  #import <ExpoModulesCore/ObjectDeallocator.h>
  
 +// [Digital Omikuji] Workaround: CallInvoker/CallbackWrapper forward declarations for iOS E2E builds.

--- a/patches/expo-modules-core@3.0.29.patch
+++ b/patches/expo-modules-core@3.0.29.patch
@@ -6,11 +6,12 @@ index 407f57f..e26a36d 100644
  #import <ReactCommon/TurboModuleUtils.h>
  #import <ExpoModulesCore/ObjectDeallocator.h>
  
-+// [Digital Omikuji] Workaround: CallInvoker forward declaration for iOS E2E builds.
++// [Digital Omikuji] Workaround: CallInvoker/CallbackWrapper forward declarations for iOS E2E builds.
 +// TODO: remove when expo-modules-core includes this upstream.
 +namespace facebook {
 +namespace react {
 +class CallInvoker;
++class CallbackWrapper;
 +}
 +}
 +

--- a/patches/expo-modules-core@3.0.29.patch
+++ b/patches/expo-modules-core@3.0.29.patch
@@ -2,7 +2,7 @@ diff --git a/ios/JSI/EXJSIUtils.h b/ios/JSI/EXJSIUtils.h
 index 407f57f..e26a36d 100644
 --- a/ios/JSI/EXJSIUtils.h
 +++ b/ios/JSI/EXJSIUtils.h
-@@ -9,6 +9,14 @@
+@@ -9,6 +9,16 @@
  #import <ReactCommon/TurboModuleUtils.h>
 +#import <ReactCommon/CallbackWrapper.h>
  #import <ExpoModulesCore/ObjectDeallocator.h>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   expo-modules-core@3.0.29:
-    hash: s4wepmod5j2pyfpue4dcp5e45y
+    hash: 5t2eq2d3ced24v77wygcj3pigy
     path: patches/expo-modules-core@3.0.29.patch
 
 importers:
@@ -10958,7 +10958,7 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
 
-  expo-modules-core@3.0.29(patch_hash=s4wepmod5j2pyfpue4dcp5e45y)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3):
+  expo-modules-core@3.0.29(patch_hash=5t2eq2d3ced24v77wygcj3pigy)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3):
     dependencies:
       invariant: 2.2.4
       react: 19.2.3
@@ -11051,7 +11051,7 @@ snapshots:
       expo-font: 14.0.10(expo@54.0.31)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)
       expo-keep-awake: 15.0.8(expo@54.0.31)(react@19.2.3)
       expo-modules-autolinking: 3.0.24
-      expo-modules-core: 3.0.29(patch_hash=s4wepmod5j2pyfpue4dcp5e45y)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)
+      expo-modules-core: 3.0.29(patch_hash=5t2eq2d3ced24v77wygcj3pigy)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)
       pretty-format: 29.7.0
       react: 19.2.3
       react-native: 0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   expo-modules-core@3.0.29:
-    hash: ugjznuzriktq73ws2jskkgq3am
+    hash: vim4ezk5tqfzng44ognqrrmnau
     path: patches/expo-modules-core@3.0.29.patch
 
 importers:
@@ -10958,7 +10958,7 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
 
-  expo-modules-core@3.0.29(patch_hash=ugjznuzriktq73ws2jskkgq3am)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3):
+  expo-modules-core@3.0.29(patch_hash=vim4ezk5tqfzng44ognqrrmnau)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3):
     dependencies:
       invariant: 2.2.4
       react: 19.2.3
@@ -11051,7 +11051,7 @@ snapshots:
       expo-font: 14.0.10(expo@54.0.31)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)
       expo-keep-awake: 15.0.8(expo@54.0.31)(react@19.2.3)
       expo-modules-autolinking: 3.0.24
-      expo-modules-core: 3.0.29(patch_hash=ugjznuzriktq73ws2jskkgq3am)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)
+      expo-modules-core: 3.0.29(patch_hash=vim4ezk5tqfzng44ognqrrmnau)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)
       pretty-format: 29.7.0
       react: 19.2.3
       react-native: 0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   expo-modules-core@3.0.29:
-    hash: vim4ezk5tqfzng44ognqrrmnau
+    hash: s4wepmod5j2pyfpue4dcp5e45y
     path: patches/expo-modules-core@3.0.29.patch
 
 importers:
@@ -10958,7 +10958,7 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
 
-  expo-modules-core@3.0.29(patch_hash=vim4ezk5tqfzng44ognqrrmnau)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3):
+  expo-modules-core@3.0.29(patch_hash=s4wepmod5j2pyfpue4dcp5e45y)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3):
     dependencies:
       invariant: 2.2.4
       react: 19.2.3
@@ -11051,7 +11051,7 @@ snapshots:
       expo-font: 14.0.10(expo@54.0.31)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)
       expo-keep-awake: 15.0.8(expo@54.0.31)(react@19.2.3)
       expo-modules-autolinking: 3.0.24
-      expo-modules-core: 3.0.29(patch_hash=vim4ezk5tqfzng44ognqrrmnau)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)
+      expo-modules-core: 3.0.29(patch_hash=s4wepmod5j2pyfpue4dcp5e45y)(react-native@0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)
       pretty-format: 29.7.0
       react: 19.2.3
       react-native: 0.83.1(@babel/core@7.28.6)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@types/react@19.2.8)(react@19.2.3)


### PR DESCRIPTION
## 目的
- iOS E2Eの`CallbackWrapper`未定義エラーを解消する

## 変更点
- `expo-modules-core@3.0.29` のpnpmパッチで `CallbackWrapper` 前方宣言を追加
- `ReactCommon/CallbackWrapper.h` を明示的にインクルード

## テスト結果ログ
- `pnpm install --lockfile-only`
  - WARN: Node 20要求 (ローカルは v22.20.0)

## 影響範囲
- iOS E2Eビルド周辺のみ（expo-modules-coreパッチ）

## スクリーンショット/動画
- なし
