### PR TITLE
[chore] ci:check 事前確認スクリプト

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "jest",
     "test:e2e:web": "playwright test",
     "test:coverage": "jest --coverage",
+    "ci:check": "pnpm install --frozen-lockfile --prefer-offline && pnpm exec tsc --noEmit && pnpm lint && pnpm lint:md && pnpm test",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint .",
     "lint:fix": "ESLINT_USE_FLAT_CONFIG=false eslint . --fix",
     "lint:md": "markdownlint .",


### PR DESCRIPTION
## 目的
- CIエラーを事前にローカルで再現・検出しやすくする

## 変更点
- `ci:check` スクリプトを追加（install + typecheck + lint + test）

## テスト結果ログ
- 未実行（スクリプト追加のみ）

## 影響範囲
- package.json の scripts のみ

## スクリーンショット/動画
- なし
