### PR TITLE
[fix] E2Eをラベル指定時のみ実行

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,7 @@ name: E2E Tests (Maestro)
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main, develop]
     paths:
       - "app/**"
@@ -33,7 +34,7 @@ jobs:
   android:
     name: Android E2E
     runs-on: ubuntu-latest
-    if: github.base_ref == 'main'
+    if: github.event_name == 'workflow_dispatch' || (github.base_ref == 'main' && contains(github.event.pull_request.labels.*.name, 'Android'))
     timeout-minutes: 25
 
     steps:
@@ -101,7 +102,7 @@ jobs:
   ios:
     name: iOS E2E
     runs-on: macos-latest
-    if: github.base_ref == 'main'
+    if: github.event_name == 'workflow_dispatch' || (github.base_ref == 'main' && contains(github.event.pull_request.labels.*.name, 'iOS'))
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## 目的
- main向けPRでも、iOS/AndroidのE2Eをラベル指定時のみ実行できるようにする

## 変更点
- PRイベントに `labeled/unlabeled` を追加
- iOS/Androidジョブをラベル条件で実行（`iOS` / `Android`）
- `workflow_dispatch` はラベル不要で実行可能

## テスト結果ログ
- 未実行（CI条件変更のみ）

## 影響範囲
- `.github/workflows/e2e.yml`

## スクリーンショット/動画
- なし
