### PR TITLE
[chore] BlacksmithラベルでCI/E2E切替

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ on:
       - "tailwind.config.js"
       - ".github/workflows/ci.yml"
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main, develop]
     paths:
       - "app/**"
@@ -51,7 +52,7 @@ concurrency:
 jobs:
   ci:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_LINUX_RUNNER || 'blacksmith') || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -17,6 +17,7 @@ on:
       - "pnpm-lock.yaml"
       - ".github/workflows/e2e-web.yml"
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main, develop]
     paths:
       - "app/**"
@@ -39,7 +40,7 @@ permissions:
 jobs:
   test:
     name: Playwright Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_LINUX_RUNNER || 'blacksmith') || 'ubuntu-latest' }}
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,7 +33,7 @@ jobs:
   # Android E2E - runs on main/develop PRs when labeled
   android:
     name: Android E2E
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_LINUX_RUNNER || 'blacksmith') || 'ubuntu-latest' }}
     if: github.event_name == 'workflow_dispatch' || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'Android'))
     timeout-minutes: 25
 
@@ -101,7 +101,7 @@ jobs:
   # iOS E2E - runs on main/develop PRs when labeled
   ios:
     name: iOS E2E
-    runs-on: macos-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_MACOS_RUNNER || 'blacksmith-macos') || 'macos-latest' }}
     if: github.event_name == 'workflow_dispatch' || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'iOS'))
     timeout-minutes: 30
 


### PR DESCRIPTION
## 目的
- Blacksmithラベルが付いたPRのみCI/E2EをBlacksmithで実行できるようにする

## 変更点
- `Blacksmith` ラベル有無で `runs-on` を切り替え
- PRイベントに `labeled/unlabeled` を追加
- `BLACKSMITH_LINUX_RUNNER` / `BLACKSMITH_MACOS_RUNNER` でランナー名を切替可能に

## テスト結果ログ
- 未実行（ワークフロー条件変更のみ）

## 影響範囲
- `.github/workflows/ci.yml`
- `.github/workflows/e2e-web.yml`
- `.github/workflows/e2e.yml`

## スクリーンショット/動画
- なし
