### PR TITLE
[chore] CI/E2EのBlacksmith切替撤回

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ on:
       - "tailwind.config.js"
       - ".github/workflows/ci.yml"
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main, develop]
     paths:
       - "app/**"
@@ -51,7 +52,7 @@ concurrency:
 jobs:
   ci:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_LINUX_RUNNER || 'blacksmith') || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ on:
       - "tailwind.config.js"
       - ".github/workflows/ci.yml"
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
     branches: [main, develop]
     paths:
       - "app/**"
@@ -52,7 +52,7 @@ concurrency:
 jobs:
   ci:
     name: ${{ matrix.name }}
-    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_LINUX_RUNNER || 'blacksmith') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -17,6 +17,7 @@ on:
       - "pnpm-lock.yaml"
       - ".github/workflows/e2e-web.yml"
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main, develop]
     paths:
       - "app/**"
@@ -39,7 +40,7 @@ permissions:
 jobs:
   test:
     name: Playwright Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_LINUX_RUNNER || 'blacksmith') || 'ubuntu-latest' }}
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -17,7 +17,7 @@ on:
       - "pnpm-lock.yaml"
       - ".github/workflows/e2e-web.yml"
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
     branches: [main, develop]
     paths:
       - "app/**"
@@ -37,10 +37,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Playwright Tests
-    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_LINUX_RUNNER || 'blacksmith') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,7 +33,7 @@ jobs:
   # Android E2E - runs on main/develop PRs when labeled
   android:
     name: Android E2E
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_LINUX_RUNNER || 'blacksmith') || 'ubuntu-latest' }}
     if: github.event_name == 'workflow_dispatch' || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'Android'))
     timeout-minutes: 25
 
@@ -101,7 +101,7 @@ jobs:
   # iOS E2E - runs on main/develop PRs when labeled
   ios:
     name: iOS E2E
-    runs-on: macos-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_MACOS_RUNNER || 'blacksmith-macos') || 'macos-latest' }}
     if: github.event_name == 'workflow_dispatch' || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'iOS'))
     timeout-minutes: 30
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,11 +29,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Android E2E - runs on main/develop PRs when labeled
   android:
     name: Android E2E
-    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_LINUX_RUNNER || 'blacksmith') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'Android'))
     timeout-minutes: 25
 
@@ -101,7 +105,7 @@ jobs:
   # iOS E2E - runs on main/develop PRs when labeled
   ios:
     name: iOS E2E
-    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_MACOS_RUNNER || 'blacksmith-macos') || 'macos-latest' }}
+    runs-on: macos-latest
     if: github.event_name == 'workflow_dispatch' || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'iOS'))
     timeout-minutes: 30
 


### PR DESCRIPTION
## 目的
- Blacksmithが使えない前提でCI/E2Eを安定運用できる設定に戻す
- 重複実行を抑制して無駄な時間とコストを削減する

## 変更点
- CI/E2Eの `runs-on` をGitHub標準ランナーに戻す
- CIのPRイベントから `labeled/unlabeled` を除外
- E2E Web / E2E（Maestro）に `concurrency` を追加

## テスト結果ログ
- 未実行（ワークフロー条件変更のみ）

## 影響範囲
- `.github/workflows/ci.yml`
- `.github/workflows/e2e-web.yml`
- `.github/workflows/e2e.yml`

## スクリーンショット/動画
- なし
