### PR TITLE
[refactor] Actions runner最適化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,24 +47,39 @@ on:
   workflow_dispatch:
     inputs:
       runner:
-        description: "Runner (ubuntu-slim is 15 min limit)"
+        description: "Runner (auto uses job classification)"
         type: choice
-        options: [ubuntu-slim, ubuntu-latest]
-        default: ubuntu-slim
+        options: [auto, slim, latest]
+        default: auto
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
-  RUNNER_LABEL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runner || 'ubuntu-slim' }}
-  TIMEOUT_MINUTES: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.runner == 'ubuntu-latest') && '360' || '15' }}
+  RUNNER_INPUT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runner || 'auto' }}
+  RUNNER_LIGHT: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.runner == 'latest') && 'ubuntu-latest' || 'ubuntu-slim' }}
+  USAGE_GUARD_THRESHOLD: "300"
 
 jobs:
+  usage-guard:
+    name: Usage Guard
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    outputs:
+      usable-minutes: ${{ steps.billing.outputs.usable-minutes }}
+    steps:
+      - name: Get billing for GitHub Actions
+        id: billing
+        uses: keita-hino/get-billing-for-github-actions@v1
+        with:
+          github-token: ${{ secrets.ACCESS_TOKEN }}
+          account-type: user
+
   ci:
     name: ${{ matrix.name }}
-    runs-on: ${{ env.RUNNER_LABEL }}
-    timeout-minutes: ${{ fromJSON(env.TIMEOUT_MINUTES) }}
+    runs-on: ${{ env.RUNNER_LIGHT }}
+    timeout-minutes: 12
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ on:
       - "tailwind.config.js"
       - ".github/workflows/ci.yml"
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main, develop]
     paths:
       - "app/**"
@@ -51,7 +52,7 @@ concurrency:
 jobs:
   ci:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_LINUX_RUNNER || 'blacksmith') || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,15 +44,27 @@ on:
       - "metro.config.js"
       - "tailwind.config.js"
       - ".github/workflows/ci.yml"
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: "Runner (ubuntu-slim is 15 min limit)"
+        type: choice
+        options: [ubuntu-slim, ubuntu-latest]
+        default: ubuntu-slim
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RUNNER_LABEL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runner || 'ubuntu-slim' }}
+  TIMEOUT_MINUTES: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.runner == 'ubuntu-latest') && '360' || '15' }}
+
 jobs:
   ci:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ env.RUNNER_LABEL }}
+    timeout-minutes: ${{ fromJSON(env.TIMEOUT_MINUTES) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ on:
       - "tailwind.config.js"
       - ".github/workflows/ci.yml"
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
     branches: [main, develop]
     paths:
       - "app/**"
@@ -52,7 +52,7 @@ concurrency:
 jobs:
   ci:
     name: ${{ matrix.name }}
-    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_LINUX_RUNNER || 'blacksmith') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -3,16 +3,28 @@ name: Deploy to Vercel
 on:
   push:
     branches: [ main, develop ]
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: "Runner (ubuntu-slim is 15 min limit)"
+        type: choice
+        options: [ubuntu-slim, ubuntu-latest]
+        default: ubuntu-latest
 
 # Prevent concurrent deployments to avoid rate limiting
 concurrency:
   group: vercel-deploy-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RUNNER_LABEL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runner || 'ubuntu-latest' }}
+  TIMEOUT_MINUTES: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.runner == 'ubuntu-slim') && '15' || '360' }}
+
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.runner != 'ubuntu-slim' }}
+    runs-on: ${{ env.RUNNER_LABEL }}
+    timeout-minutes: ${{ fromJSON(env.TIMEOUT_MINUTES) }}
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
@@ -55,4 +67,3 @@ jobs:
       - name: Deploy Project Artifacts to Vercel (Preview)
         if: github.ref != 'refs/heads/main'
         run: vercel deploy --prebuilt --token=$VERCEL_TOKEN
-

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -6,10 +6,10 @@ on:
   workflow_dispatch:
     inputs:
       runner:
-        description: "Runner (ubuntu-slim is 15 min limit)"
+        description: "Runner (auto uses job classification)"
         type: choice
-        options: [ubuntu-slim, ubuntu-latest]
-        default: ubuntu-latest
+        options: [auto, slim, latest]
+        default: auto
 
 # Prevent concurrent deployments to avoid rate limiting
 concurrency:
@@ -17,14 +17,30 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUNNER_LABEL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runner || 'ubuntu-latest' }}
-  TIMEOUT_MINUTES: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.runner == 'ubuntu-slim') && '15' || '360' }}
+  RUNNER_INPUT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runner || 'auto' }}
+  RUNNER_HEAVY: ubuntu-latest
+  USAGE_GUARD_THRESHOLD: "300"
 
 jobs:
+  usage-guard:
+    name: Usage Guard
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    outputs:
+      usable-minutes: ${{ steps.billing.outputs.usable-minutes }}
+    steps:
+      - name: Get billing for GitHub Actions
+        id: billing
+        uses: keita-hino/get-billing-for-github-actions@v1
+        with:
+          github-token: ${{ secrets.ACCESS_TOKEN }}
+          account-type: user
+
   deploy:
-    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.runner != 'ubuntu-slim' }}
-    runs-on: ${{ env.RUNNER_LABEL }}
-    timeout-minutes: ${{ fromJSON(env.TIMEOUT_MINUTES) }}
+    needs: usage-guard
+    if: ${{ needs.usage-guard.result == 'success' && fromJSON(needs.usage-guard.outputs.usable-minutes) >= fromJSON(env.USAGE_GUARD_THRESHOLD) }}
+    runs-on: ${{ env.RUNNER_HEAVY }}
+    timeout-minutes: 15
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -17,6 +17,7 @@ on:
       - "pnpm-lock.yaml"
       - ".github/workflows/e2e-web.yml"
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main, develop]
     paths:
       - "app/**"
@@ -39,7 +40,7 @@ permissions:
 jobs:
   test:
     name: Playwright Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_LINUX_RUNNER || 'blacksmith') || 'ubuntu-latest' }}
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -72,7 +72,6 @@ jobs:
     needs: usage-guard
     if: ${{ needs.usage-guard.result == 'success' && fromJSON(needs.usage-guard.outputs.usable-minutes) >= fromJSON(env.USAGE_GUARD_THRESHOLD) }}
     runs-on: ${{ env.RUNNER_HEAVY }}
-    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -33,6 +33,12 @@ on:
       - "pnpm-lock.yaml"
       - ".github/workflows/e2e-web.yml"
   workflow_dispatch:
+    inputs:
+      runner:
+        description: "Runner (ubuntu-slim is 15 min limit)"
+        type: choice
+        options: [ubuntu-slim, ubuntu-latest]
+        default: ubuntu-latest
 
 permissions:
   contents: read
@@ -41,11 +47,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RUNNER_LABEL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runner || 'ubuntu-latest' }}
+  TIMEOUT_MINUTES: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.runner == 'ubuntu-slim') && '15' || '360' }}
+
 jobs:
   test:
     name: Playwright Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.runner != 'ubuntu-slim' }}
+    runs-on: ${{ env.RUNNER_LABEL }}
+    timeout-minutes: ${{ fromJSON(env.TIMEOUT_MINUTES) }}
+    env:
+      RUNNER_LABEL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runner || 'ubuntu-latest' }}
+      TIMEOUT_MINUTES: "360"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -35,10 +35,10 @@ on:
   workflow_dispatch:
     inputs:
       runner:
-        description: "Runner (ubuntu-slim is 15 min limit)"
+        description: "Runner (auto uses job classification)"
         type: choice
-        options: [ubuntu-slim, ubuntu-latest]
-        default: ubuntu-latest
+        options: [auto, slim, latest]
+        default: auto
 
 permissions:
   contents: read
@@ -48,18 +48,31 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUNNER_LABEL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runner || 'ubuntu-latest' }}
-  TIMEOUT_MINUTES: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.runner == 'ubuntu-slim') && '15' || '360' }}
+  RUNNER_INPUT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runner || 'auto' }}
+  RUNNER_HEAVY: ubuntu-latest
+  USAGE_GUARD_THRESHOLD: "300"
 
 jobs:
+  usage-guard:
+    name: Usage Guard
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    outputs:
+      usable-minutes: ${{ steps.billing.outputs.usable-minutes }}
+    steps:
+      - name: Get billing for GitHub Actions
+        id: billing
+        uses: keita-hino/get-billing-for-github-actions@v1
+        with:
+          github-token: ${{ secrets.ACCESS_TOKEN }}
+          account-type: user
+
   test:
     name: Playwright Tests
-    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.runner != 'ubuntu-slim' }}
-    runs-on: ${{ env.RUNNER_LABEL }}
-    timeout-minutes: ${{ fromJSON(env.TIMEOUT_MINUTES) }}
-    env:
-      RUNNER_LABEL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runner || 'ubuntu-latest' }}
-      TIMEOUT_MINUTES: "360"
+    needs: usage-guard
+    if: ${{ needs.usage-guard.result == 'success' && fromJSON(needs.usage-guard.outputs.usable-minutes) >= fromJSON(env.USAGE_GUARD_THRESHOLD) }}
+    runs-on: ${{ env.RUNNER_HEAVY }}
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -17,7 +17,7 @@ on:
       - "pnpm-lock.yaml"
       - ".github/workflows/e2e-web.yml"
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
     branches: [main, develop]
     paths:
       - "app/**"
@@ -37,10 +37,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Playwright Tests
-    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_LINUX_RUNNER || 'blacksmith') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,6 +25,12 @@ on:
       - "nativewind-env.d.ts"
       - ".github/workflows/e2e.yml"
   workflow_dispatch:
+    inputs:
+      runner:
+        description: "Runner (ubuntu-slim is 15 min limit)"
+        type: choice
+        options: [ubuntu-slim, ubuntu-latest]
+        default: ubuntu-latest
 
 permissions:
   contents: read
@@ -33,13 +39,20 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RUNNER_LABEL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runner || 'ubuntu-latest' }}
+  TIMEOUT_MINUTES: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.runner == 'ubuntu-slim') && '15' || '360' }}
+
 jobs:
   # Android E2E - runs on main/develop PRs when labeled
   android:
     name: Android E2E
-    runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'Android'))
-    timeout-minutes: 25
+    if: (github.event_name == 'workflow_dispatch' || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'Android'))) && (github.event_name != 'workflow_dispatch' || github.event.inputs.runner != 'ubuntu-slim')
+    runs-on: ${{ env.RUNNER_LABEL }}
+    timeout-minutes: ${{ fromJSON(env.TIMEOUT_MINUTES) }}
+    env:
+      RUNNER_LABEL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runner || 'ubuntu-latest' }}
+      TIMEOUT_MINUTES: "360"
 
     steps:
       - uses: actions/checkout@v6
@@ -106,7 +119,7 @@ jobs:
   ios:
     name: iOS E2E
     runs-on: macos-latest
-    if: github.event_name == 'workflow_dispatch' || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'iOS'))
+    if: (github.event_name == 'workflow_dispatch' && github.event.inputs.runner != 'ubuntu-slim') || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'iOS'))
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,10 +27,10 @@ on:
   workflow_dispatch:
     inputs:
       runner:
-        description: "Runner (ubuntu-slim is 15 min limit)"
+        description: "Runner (auto uses job classification)"
         type: choice
-        options: [ubuntu-slim, ubuntu-latest]
-        default: ubuntu-latest
+        options: [auto, slim, latest]
+        default: auto
 
 permissions:
   contents: read
@@ -40,19 +40,32 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUNNER_LABEL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runner || 'ubuntu-latest' }}
-  TIMEOUT_MINUTES: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.runner == 'ubuntu-slim') && '15' || '360' }}
+  RUNNER_INPUT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runner || 'auto' }}
+  RUNNER_HEAVY: ubuntu-latest
+  USAGE_GUARD_THRESHOLD: "300"
 
 jobs:
+  usage-guard:
+    name: Usage Guard
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    outputs:
+      usable-minutes: ${{ steps.billing.outputs.usable-minutes }}
+    steps:
+      - name: Get billing for GitHub Actions
+        id: billing
+        uses: keita-hino/get-billing-for-github-actions@v1
+        with:
+          github-token: ${{ secrets.ACCESS_TOKEN }}
+          account-type: user
+
   # Android E2E - runs on main/develop PRs when labeled
   android:
     name: Android E2E
-    if: (github.event_name == 'workflow_dispatch' || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'Android'))) && (github.event_name != 'workflow_dispatch' || github.event.inputs.runner != 'ubuntu-slim')
-    runs-on: ${{ env.RUNNER_LABEL }}
-    timeout-minutes: ${{ fromJSON(env.TIMEOUT_MINUTES) }}
-    env:
-      RUNNER_LABEL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runner || 'ubuntu-latest' }}
-      TIMEOUT_MINUTES: "360"
+    needs: usage-guard
+    if: (github.event_name == 'workflow_dispatch' || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'Android'))) && needs.usage-guard.result == 'success' && fromJSON(needs.usage-guard.outputs.usable-minutes) >= fromJSON(env.USAGE_GUARD_THRESHOLD)
+    runs-on: ${{ env.RUNNER_HEAVY }}
+    timeout-minutes: 25
 
     steps:
       - uses: actions/checkout@v6
@@ -119,7 +132,8 @@ jobs:
   ios:
     name: iOS E2E
     runs-on: macos-latest
-    if: (github.event_name == 'workflow_dispatch' && github.event.inputs.runner != 'ubuntu-slim') || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'iOS'))
+    needs: usage-guard
+    if: (github.event_name == 'workflow_dispatch' || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'iOS'))) && needs.usage-guard.result == 'success' && fromJSON(needs.usage-guard.outputs.usable-minutes) >= fromJSON(env.USAGE_GUARD_THRESHOLD)
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,7 +33,7 @@ jobs:
   # Android E2E - runs on main/develop PRs when labeled
   android:
     name: Android E2E
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_LINUX_RUNNER || 'blacksmith') || 'ubuntu-latest' }}
     if: github.event_name == 'workflow_dispatch' || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'Android'))
     timeout-minutes: 25
 
@@ -101,7 +101,7 @@ jobs:
   # iOS E2E - runs on main/develop PRs when labeled
   ios:
     name: iOS E2E
-    runs-on: macos-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_MACOS_RUNNER || 'blacksmith-macos') || 'macos-latest' }}
     if: github.event_name == 'workflow_dispatch' || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'iOS'))
     timeout-minutes: 30
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,11 +29,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Android E2E - runs on main/develop PRs when labeled
   android:
     name: Android E2E
-    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_LINUX_RUNNER || 'blacksmith') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'Android'))
     timeout-minutes: 25
 
@@ -101,7 +105,7 @@ jobs:
   # iOS E2E - runs on main/develop PRs when labeled
   ios:
     name: iOS E2E
-    runs-on: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Blacksmith')) && (vars.BLACKSMITH_MACOS_RUNNER || 'blacksmith-macos') || 'macos-latest' }}
+    runs-on: macos-latest
     if: github.event_name == 'workflow_dispatch' || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'iOS'))
     timeout-minutes: 30
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,7 +65,6 @@ jobs:
     needs: usage-guard
     if: (github.event_name == 'workflow_dispatch' || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'Android'))) && needs.usage-guard.result == 'success' && fromJSON(needs.usage-guard.outputs.usable-minutes) >= fromJSON(env.USAGE_GUARD_THRESHOLD)
     runs-on: ${{ env.RUNNER_HEAVY }}
-    timeout-minutes: 25
 
     steps:
       - uses: actions/checkout@v6
@@ -134,7 +133,6 @@ jobs:
     runs-on: macos-latest
     needs: usage-guard
     if: (github.event_name == 'workflow_dispatch' || ((github.base_ref == 'main' || github.base_ref == 'develop') && contains(github.event.pull_request.labels.*.name, 'iOS'))) && needs.usage-guard.result == 'success' && fromJSON(needs.usage-guard.outputs.usable-minutes) >= fromJSON(env.USAGE_GUARD_THRESHOLD)
-    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/river-reviewer.yml
+++ b/.github/workflows/river-reviewer.yml
@@ -3,11 +3,23 @@ name: River Reviewer
 on:
   pull_request:
     branches: [main, develop]
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: "Runner (ubuntu-slim is 15 min limit)"
+        type: choice
+        options: [ubuntu-slim, ubuntu-latest]
+        default: ubuntu-slim
+
+env:
+  RUNNER_LABEL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runner || 'ubuntu-slim' }}
+  TIMEOUT_MINUTES: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.runner == 'ubuntu-latest') && '360' || '15' }}
 
 jobs:
   review:
     name: AI Code Review
-    runs-on: ubuntu-latest
+    runs-on: ${{ env.RUNNER_LABEL }}
+    timeout-minutes: ${{ fromJSON(env.TIMEOUT_MINUTES) }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/river-reviewer.yml
+++ b/.github/workflows/river-reviewer.yml
@@ -6,20 +6,35 @@ on:
   workflow_dispatch:
     inputs:
       runner:
-        description: "Runner (ubuntu-slim is 15 min limit)"
+        description: "Runner (auto uses job classification)"
         type: choice
-        options: [ubuntu-slim, ubuntu-latest]
-        default: ubuntu-slim
+        options: [auto, slim, latest]
+        default: auto
 
 env:
-  RUNNER_LABEL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runner || 'ubuntu-slim' }}
-  TIMEOUT_MINUTES: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.runner == 'ubuntu-latest') && '360' || '15' }}
+  RUNNER_INPUT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runner || 'auto' }}
+  RUNNER_LIGHT: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.runner == 'latest') && 'ubuntu-latest' || 'ubuntu-slim' }}
+  USAGE_GUARD_THRESHOLD: "300"
 
 jobs:
+  usage-guard:
+    name: Usage Guard
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    outputs:
+      usable-minutes: ${{ steps.billing.outputs.usable-minutes }}
+    steps:
+      - name: Get billing for GitHub Actions
+        id: billing
+        uses: keita-hino/get-billing-for-github-actions@v1
+        with:
+          github-token: ${{ secrets.ACCESS_TOKEN }}
+          account-type: user
+
   review:
     name: AI Code Review
-    runs-on: ${{ env.RUNNER_LABEL }}
-    timeout-minutes: ${{ fromJSON(env.TIMEOUT_MINUTES) }}
+    runs-on: ${{ env.RUNNER_LIGHT }}
+    timeout-minutes: 12
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
目的
- Actions無料枠を意識して ubuntu-slim/ubuntu-latest を使い分け、残分が少ない場合は重いジョブをスキップする

変更点
- workflow_dispatch の runner 入力を auto/slim/latest に統一（auto が分類ルールを使用）
- usage-guard を追加し、usable-minutes が閾値未満のとき重いジョブをスキップ
- 軽微ジョブは ubuntu-slim + timeout-minutes 12、重いジョブは ubuntu-latest を維持

テスト結果ログ
- 未実施

影響範囲
- .github/workflows/*.yml

備考
- usage-guard は Secrets.ACCESS_TOKEN（Plan:Read only）で Actions利用状況を取得するために使用