### PR TITLE
fix: PR #301 レビュー指摘対応 — isAvailableAsync モック・globals 明示依存

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -73,6 +73,7 @@ jest.mock("expo-sensors", () => ({
     addListener: jest.fn(),
     setUpdateInterval: jest.fn(),
     removeAllListeners: jest.fn(),
+    isAvailableAsync: jest.fn(() => Promise.resolve(true)),
   },
 }));
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint-config-expo": "^55.0.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
+    "globals": "^17.4.0",
     "jest": "^30.3.0",
     "jest-expo": "~55.0.14",
     "markdownlint-cli": "^0.48.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.5.4
         version: 5.5.5(eslint-config-prettier@10.1.8(eslint@10.2.0(jiti@1.21.7)))(eslint@10.2.0(jiti@1.21.7))(prettier@3.8.1)
+      globals:
+        specifier: ^17.4.0
+        version: 17.4.0
       jest:
         specifier: ^30.3.0
         version: 30.3.0(@types/node@25.5.2)(ts-node@10.9.2(@types/node@25.5.2)(typescript@5.9.3))
@@ -3827,6 +3830,10 @@ packages:
 
   globals@16.5.0:
     resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
+    engines: {node: '>=18'}
+
+  globals@17.4.0:
+    resolution: {integrity: sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -9355,7 +9362,9 @@ snapshots:
       metro-runtime: 0.83.5
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 
@@ -11911,6 +11920,8 @@ snapshots:
       ini: 1.3.8
 
   globals@16.5.0: {}
+
+  globals@17.4.0: {}
 
   globalthis@1.0.4:
     dependencies:


### PR DESCRIPTION
## 目的

PR #301 のマージ後に残っていたレビュー指摘事項を対応する follow-up PR。

## 変更点

- **jest.setup.js**: `Accelerometer.isAvailableAsync` モックを追加
  - 指摘元: Sentry Bot + Copilot（#301）
  - `useShakeDetection` フックが `isAvailableAsync()` を呼ぶが、モックが未定義のため Platform.OS が mobile の場合に `TypeError` になりうる潜在バグを修正
- **package.json**: `globals` パッケージを devDependencies に明示追加
  - 指摘元: Copilot（#301）
  - `eslint.config.js` が `require("globals")` しているが、`eslint-config-expo` の推移的依存に頼っており、pnpm の hoist 設定次第で `Cannot find module` エラーになりうる

## 動作確認

```
$ pnpm test

Test Suites: 14 passed, 14 total
Tests:       64 passed, 64 total
Snapshots:   0 total
Time:        4.681 s
```

## 影響範囲 / リスク

- 破壊的変更: なし
- テスト環境のみに影響（jest.setup.js のモック追加）
- `globals` は既に推移的依存で存在、明示化するだけ

## レビュー依頼（必須）

- [ ] Copilot
- [ ] Gemini

## ロールバック手順

```bash
git revert <commit-hash>
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)