### PR TITLE
fix: codex.md の相対パスを修正（Copilot指摘 #304）

### DIFF
--- a/.codex/codex.md
+++ b/.codex/codex.md
@@ -5,8 +5,8 @@
 ## Codex-specific settings
 
 - Config: See `.codex/config.toml` for approval policy and sandbox mode
-- Detailed instructions: See `AGENTS.md`
-- Agent Skills: See `.agent/ARCHITECTURE.md`
+- Detailed instructions: See `../AGENTS.md`
+- Agent Skills: See `../.agent/ARCHITECTURE.md`
 
 ## Quick reference (from AGENTS.md)
 


### PR DESCRIPTION
## 目的

PR #304 の Copilot レビュー指摘に対する follow-up。`.codex/` 配下から `AGENTS.md` を参照する際の相対パスを修正。

## 変更点

- `.codex/codex.md`: `AGENTS.md` → `../AGENTS.md`、`.agent/ARCHITECTURE.md` → `../.agent/ARCHITECTURE.md`
- `.codex/` ディレクトリからルートファイルを指す際、ディレクトリを跨ぐことが明確になるよう `../` を付与

## 影響範囲 / リスク

なし（ドキュメントのみ）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)