### PR TITLE
[chore] 残タスク一括対応 — サブモジュール同期・lint解消・エンジン要件緩和

### DIFF
--- a/i18n/index.ts
+++ b/i18n/index.ts
@@ -7,8 +7,9 @@ import en from "./locales/en.json";
 // デバイスの言語設定を取得
 const deviceLanguage = getLocales()[0]?.languageCode ?? "ja";
 
+// eslint-disable-next-line import/no-named-as-default-member -- i18next公式パターン: default instanceの.use()メソッド呼び出し
 i18n
-  .use(initReactI18next) // passes i18n down to react-i18next
+  .use(initReactI18next)
   .init({
     resources: {
       ja: { translation: ja },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "main": "expo-router/entry",
   "engines": {
-    "node": "20.x"
+    "node": ">=20"
   },
   "packageManager": "pnpm@9.15.2",
   "scripts": {


### PR DESCRIPTION
## 目的

振り返りで挙がった残タスク（高〜中優先度）を一括で対応する。

## 変更点

- **`river-reviewer`**: サブモジュール参照を最新 (`2a1cbd6`) に更新（239コミット分の遅れを解消）
- **`i18n/index.ts`**: `import/no-named-as-default-member` warning を `eslint-disable` で抑制（i18next公式パターンの誤検出）
- **`package.json`**: `engines.node` を `"20.x"` → `">=20"` に緩和（Expo SDK 54 は Node 18+ 対応、実環境 v25 との不一致を解消）

## 動作確認

```
$ pnpm lint
# 0 errors, 0 warnings（warning 1件が解消）

$ pnpm test
Test Suites: 14 passed, 14 total
Tests:       64 passed, 64 total
Time:        3.389 s
```

## 影響範囲 / リスク

- **river-reviewer**: サブモジュール参照のみ。アプリコードへの影響なし
- **i18n/index.ts**: eslint-disable コメント追加のみ。ランタイム変更なし
- **package.json**: エンジン要件の緩和。既存環境への影響なし（制約が緩くなるだけ）
- **破壊的変更**: なし

## UI 変更

なし

## レビュー依頼（必須）

- [ ] Copilot
- [ ] Gemini
- [ ] Codex

## ロールバック手順

```bash
git revert <merge-commit-hash>
```