### PR TITLE
fix: Web で findNodeHandle クラッシュを修正し E2E テストを復旧

### DIFF
--- a/components/templates/ExperienceScreenTemplate.tsx
+++ b/components/templates/ExperienceScreenTemplate.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef } from "react";
 import {
-  findNodeHandle,
   ImageBackground,
   Platform,
   ScrollView,
@@ -67,13 +66,7 @@ export function ExperienceScreenTemplate({
     }
 
     const overlayCurrent = overlayContainerRef.current as unknown;
-    const overlayHandle = findNodeHandle(overlayContainerRef.current) as unknown;
-    const overlayElement =
-      overlayCurrent instanceof HTMLElement
-        ? overlayCurrent
-        : overlayHandle instanceof HTMLElement
-          ? overlayHandle
-          : null;
+    const overlayElement = overlayCurrent instanceof HTMLElement ? overlayCurrent : null;
 
     if (!overlayElement) {
       return;

--- a/e2e/web/app.spec.ts
+++ b/e2e/web/app.spec.ts
@@ -18,8 +18,7 @@ test.describe("Digital Omikuji Web", () => {
     });
   });
 
-  // TODO: Web ビルドでおみくじ引き後のアニメーションが完了しない問題を調査 (see Issue)
-  test.skip("should draw omikuji and show result", async ({ page }) => {
+  test("should draw omikuji and show result", async ({ page }) => {
     await gotoRoute(page, "/");
 
     const drawButton = page.getByRole("button", { name: "おみくじを引く" });
@@ -28,7 +27,9 @@ test.describe("Digital Omikuji Web", () => {
 
     await expect(page.getByText("念を込めて...")).toBeVisible({ timeout: 10000 });
 
-    await expect(page.getByText(/大吉|吉|中吉|小吉|末吉|凶/)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/大吉|中吉|小吉|末吉|凶|吉/).first()).toBeVisible({
+      timeout: 15000,
+    });
   });
 
   test("history direct entry returns to home", async ({ page }) => {

--- a/patches/expo-modules-core@3.0.29.patch
+++ b/patches/expo-modules-core@3.0.29.patch
@@ -2,7 +2,7 @@ diff --git a/ios/JSI/EXJSIUtils.h b/ios/JSI/EXJSIUtils.h
 index 407f57f..e26a36d 100644
 --- a/ios/JSI/EXJSIUtils.h
 +++ b/ios/JSI/EXJSIUtils.h
-@@ -9,6 +9,16 @@
+@@ -9,6 +9,17 @@
  #import <ReactCommon/TurboModuleUtils.h>
 +#import <ReactCommon/CallbackWrapper.h>
  #import <ExpoModulesCore/ObjectDeallocator.h>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   expo-modules-core@3.0.29:
-    hash: 5t2eq2d3ced24v77wygcj3pigy
+    hash: mioqr4o762t4fdd3wlk2btd7ay
     path: patches/expo-modules-core@3.0.29.patch
 
 importers:
@@ -11504,7 +11504,7 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
 
-  expo-modules-core@3.0.29(patch_hash=5t2eq2d3ced24v77wygcj3pigy)(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4):
+  expo-modules-core@3.0.29(patch_hash=mioqr4o762t4fdd3wlk2btd7ay)(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4):
     dependencies:
       invariant: 2.2.4
       react: 19.2.4
@@ -11597,7 +11597,7 @@ snapshots:
       expo-font: 14.0.11(expo@54.0.33)(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
       expo-keep-awake: 15.0.8(expo@54.0.33)(react@19.2.4)
       expo-modules-autolinking: 3.0.24
-      expo-modules-core: 3.0.29(patch_hash=5t2eq2d3ced24v77wygcj3pigy)(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
+      expo-modules-core: 3.0.29(patch_hash=mioqr4o762t4fdd3wlk2btd7ay)(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
       pretty-format: 29.7.0
       react: 19.2.4
       react-native: 0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4)


### PR DESCRIPTION
## Summary

- `ExperienceScreenTemplate` で `findNodeHandle` を Web 環境で呼んでいたが、React Native 0.84+ では非サポートとなりオーバーレイ表示時に画面がクラッシュしていた
- `ref.current` から直接 `HTMLElement` を取得する方法に変更し、`findNodeHandle` の import も削除
- E2E テストの `test.skip` を解除し、全テストを有効化
- `getByText` の strict mode violation を `.first()` で回避

## 根本原因

```typescript
// Before: Web 非サポートの findNodeHandle を使用
const overlayHandle = findNodeHandle(overlayContainerRef.current);

// After: ref から直接 HTMLElement を取得
const overlayCurrent = overlayContainerRef.current as unknown;
const overlayElement = overlayCurrent instanceof HTMLElement ? overlayCurrent : null;
```

## Test plan

- [x] `pnpm test` — 全64テストパス
- [x] `pnpm lint` — パス
- [x] Playwright E2E (chromium) — 全4テストパス（ローカル検証済み）
- [x] Playwright E2E (Mobile Chrome) — 全4テストパス（ローカル検証済み）
- [ ] CI で全チェック green を確認

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)