### PR TITLE
test: テストカバレッジを 81.96% に向上（目標 80% 達成）

### DIFF
--- a/components/design-system/__tests__/PaperResultCard.test.tsx
+++ b/components/design-system/__tests__/PaperResultCard.test.tsx
@@ -78,6 +78,43 @@ describe("PaperResultCard", () => {
     consoleErrorSpy.mockRestore();
   });
 
+  it("handleTie sets exit animation and shows tied complete after timeout", async () => {
+    jest.useFakeTimers();
+    const { getByText, queryByText } = render(
+      <PaperResultCard fortune={mockFortune} onReset={jest.fn()} reducedMotion />
+    );
+
+    fireEvent.press(getByText("結ぶ"));
+
+    expect(queryByText("結びました")).toBeNull();
+
+    jest.advanceTimersByTime(1200);
+
+    await waitFor(() => {
+      expect(getByText("結びました")).toBeTruthy();
+    });
+
+    jest.useRealTimers();
+  });
+
+  it("handleKeep calls onReset after animation", () => {
+    jest.useFakeTimers();
+    const onReset = jest.fn();
+    const { getByText } = render(
+      <PaperResultCard fortune={mockFortune} onReset={onReset} reducedMotion />
+    );
+
+    fireEvent.press(getByText("持ち帰る"));
+
+    expect(onReset).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(800);
+
+    expect(onReset).toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
+
   it("falls back to text sharing when image capture fails", async () => {
     const { getByText } = render(
       <PaperResultCard fortune={mockFortune} onReset={jest.fn()} reducedMotion />

--- a/hooks/__tests__/useShakeDetection.test.ts
+++ b/hooks/__tests__/useShakeDetection.test.ts
@@ -1,0 +1,125 @@
+import { renderHook, act } from "@testing-library/react-native";
+import { Platform } from "react-native";
+import { Accelerometer } from "expo-sensors";
+import { useShakeDetection } from "../useShakeDetection";
+
+jest.mock("expo-sensors", () => ({
+  Accelerometer: {
+    isAvailableAsync: jest.fn(),
+    setUpdateInterval: jest.fn(),
+    addListener: jest.fn(),
+  },
+}));
+
+describe("useShakeDetection", () => {
+  let listenerCallback: ((data: { x: number; y: number; z: number }) => void) | null = null;
+  const mockRemove = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    listenerCallback = null;
+    (Platform as { OS: string }).OS = "ios";
+
+    (Accelerometer.isAvailableAsync as jest.Mock).mockResolvedValue(true);
+    (Accelerometer.addListener as jest.Mock).mockImplementation((cb) => {
+      listenerCallback = cb;
+      return { remove: mockRemove };
+    });
+  });
+
+  it("does nothing on web platform", () => {
+    (Platform as { OS: string }).OS = "web";
+    const onShake = jest.fn();
+
+    renderHook(() => useShakeDetection({ enabled: true, threshold: 1.8, onShake }));
+
+    expect(Accelerometer.isAvailableAsync).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when disabled", () => {
+    const onShake = jest.fn();
+
+    renderHook(() => useShakeDetection({ enabled: false, threshold: 1.8, onShake }));
+
+    expect(Accelerometer.isAvailableAsync).not.toHaveBeenCalled();
+  });
+
+  it("sets up accelerometer when enabled and available", async () => {
+    const onShake = jest.fn();
+
+    renderHook(() => useShakeDetection({ enabled: true, threshold: 1.8, onShake }));
+
+    await act(async () => {});
+
+    expect(Accelerometer.isAvailableAsync).toHaveBeenCalled();
+    expect(Accelerometer.setUpdateInterval).toHaveBeenCalledWith(100);
+    expect(Accelerometer.addListener).toHaveBeenCalled();
+  });
+
+  it("calls onShake when force exceeds threshold", async () => {
+    const onShake = jest.fn();
+
+    renderHook(() => useShakeDetection({ enabled: true, threshold: 1.8, onShake }));
+
+    await act(async () => {});
+
+    expect(listenerCallback).not.toBeNull();
+    act(() => {
+      listenerCallback!({ x: 2.0, y: 0, z: 0 });
+    });
+
+    expect(onShake).toHaveBeenCalled();
+  });
+
+  it("does not call onShake when force is below threshold", async () => {
+    const onShake = jest.fn();
+
+    renderHook(() => useShakeDetection({ enabled: true, threshold: 1.8, onShake }));
+
+    await act(async () => {});
+
+    act(() => {
+      listenerCallback!({ x: 0.5, y: 0.5, z: 0.5 });
+    });
+
+    expect(onShake).not.toHaveBeenCalled();
+  });
+
+  it("does not set up listener when accelerometer unavailable", async () => {
+    (Accelerometer.isAvailableAsync as jest.Mock).mockResolvedValue(false);
+    const onShake = jest.fn();
+
+    renderHook(() => useShakeDetection({ enabled: true, threshold: 1.8, onShake }));
+
+    await act(async () => {});
+
+    expect(Accelerometer.addListener).not.toHaveBeenCalled();
+  });
+
+  it("handles accelerometer initialization failure gracefully", async () => {
+    (Accelerometer.isAvailableAsync as jest.Mock).mockRejectedValue(new Error("sensor error"));
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+    const onShake = jest.fn();
+
+    renderHook(() => useShakeDetection({ enabled: true, threshold: 1.8, onShake }));
+
+    await act(async () => {});
+
+    expect(warnSpy).toHaveBeenCalledWith("Accelerometer initialization failed:", expect.any(Error));
+    warnSpy.mockRestore();
+  });
+
+  it("removes subscription on cleanup", async () => {
+    const onShake = jest.fn();
+
+    const { unmount } = renderHook(() =>
+      useShakeDetection({ enabled: true, threshold: 1.8, onShake })
+    );
+
+    await act(async () => {});
+
+    unmount();
+
+    expect(mockRemove).toHaveBeenCalled();
+  });
+});

--- a/utils/__tests__/haptics.test.ts
+++ b/utils/__tests__/haptics.test.ts
@@ -1,0 +1,45 @@
+import { Platform } from "react-native";
+import * as Haptics from "expo-haptics";
+import { triggerHaptic } from "../haptics";
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(),
+  notificationAsync: jest.fn(),
+  ImpactFeedbackStyle: { Light: "LIGHT", Medium: "MEDIUM", Heavy: "HEAVY" },
+  NotificationFeedbackType: { Success: "SUCCESS", Warning: "WARNING", Error: "ERROR" },
+}));
+
+describe("triggerHaptic", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Platform as { OS: string }).OS = "ios";
+  });
+
+  it("does nothing on web", () => {
+    (Platform as { OS: string }).OS = "web";
+    triggerHaptic({ type: "impact", style: Haptics.ImpactFeedbackStyle.Medium });
+    expect(Haptics.impactAsync).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when reducedMotion is true and force is false", () => {
+    triggerHaptic({ type: "impact", style: Haptics.ImpactFeedbackStyle.Medium }, false, true);
+    expect(Haptics.impactAsync).not.toHaveBeenCalled();
+  });
+
+  it("triggers haptic when reducedMotion is true but force is true", () => {
+    triggerHaptic({ type: "impact", style: Haptics.ImpactFeedbackStyle.Medium }, true, true);
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Medium);
+  });
+
+  it("triggers impactAsync for impact type", () => {
+    triggerHaptic({ type: "impact", style: Haptics.ImpactFeedbackStyle.Heavy });
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Heavy);
+  });
+
+  it("triggers notificationAsync for notification type", () => {
+    triggerHaptic({ type: "notification", style: Haptics.NotificationFeedbackType.Success });
+    expect(Haptics.notificationAsync).toHaveBeenCalledWith(
+      Haptics.NotificationFeedbackType.Success
+    );
+  });
+});

--- a/utils/__tests__/sentry.test.ts
+++ b/utils/__tests__/sentry.test.ts
@@ -1,0 +1,101 @@
+const mockInit = jest.fn();
+const mockCaptureException = jest.fn();
+const mockCaptureMessage = jest.fn();
+const mockSetContext = jest.fn();
+
+jest.mock("@sentry/react-native", () => ({
+  init: mockInit,
+  captureException: mockCaptureException,
+  captureMessage: mockCaptureMessage,
+  setContext: mockSetContext,
+}));
+
+jest.mock("expo-constants", () => ({
+  expoConfig: {
+    version: "1.1.0",
+    extra: { appVariant: "development" },
+  },
+}));
+
+describe("sentry", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("warns and skips init when DSN is not configured", () => {
+    process.env.EXPO_PUBLIC_SENTRY_DSN = "";
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+
+    const { initializeSentry } = require("../sentry");
+    initializeSentry();
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Sentry DSN not configured"));
+    expect(mockInit).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it("initializes Sentry with correct config when DSN is set", () => {
+    process.env.EXPO_PUBLIC_SENTRY_DSN = "https://test@sentry.io/123";
+
+    const { initializeSentry } = require("../sentry");
+    initializeSentry();
+
+    expect(mockInit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dsn: "https://test@sentry.io/123",
+        environment: "development",
+        release: "digital-omikuji@1.1.0",
+      })
+    );
+  });
+
+  it("captureException sends error to Sentry", () => {
+    process.env.EXPO_PUBLIC_SENTRY_DSN = "";
+    const { captureException } = require("../sentry");
+    const error = new Error("test error");
+
+    captureException(error);
+
+    expect(mockCaptureException).toHaveBeenCalledWith(error);
+    expect(mockSetContext).not.toHaveBeenCalled();
+  });
+
+  it("captureException sets context when provided", () => {
+    process.env.EXPO_PUBLIC_SENTRY_DSN = "";
+    const { captureException } = require("../sentry");
+    const error = new Error("test error");
+    const context = { userId: "123" };
+
+    captureException(error, context);
+
+    expect(mockSetContext).toHaveBeenCalledWith("additional", context);
+    expect(mockCaptureException).toHaveBeenCalledWith(error);
+  });
+
+  it("captureMessage sends message to Sentry", () => {
+    process.env.EXPO_PUBLIC_SENTRY_DSN = "";
+    const { captureMessage } = require("../sentry");
+
+    captureMessage("test message", "warning");
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith("test message", "warning");
+  });
+
+  it("captureMessage defaults to info level", () => {
+    process.env.EXPO_PUBLIC_SENTRY_DSN = "";
+    const { captureMessage } = require("../sentry");
+
+    captureMessage("info message");
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith("info message", "info");
+  });
+});


### PR DESCRIPTION
## Summary

Issue #31 の完了条件「主要ロジックのテストカバレッジが80%以上」を達成。

**75.75% → 81.96%** (+6.21%)

### 新規テストファイル
| ファイル | テスト数 | カバレッジ |
|---------|---------|-----------|
| `utils/__tests__/haptics.test.ts` | 5件 | 100% (0% → 100%) |
| `utils/__tests__/sentry.test.ts` | 6件 | 100% (0% → 100%) |
| `hooks/__tests__/useShakeDetection.test.ts` | 8件 | 100% (78.94% → 100%) |

### 既存テスト拡充
| ファイル | テスト数 | カバレッジ |
|---------|---------|-----------|
| `PaperResultCard.test.tsx` | +2件 | 67.18% (45.58% → 67.18%) |

テスト合計: **64件 → 85件** (+21件)

## Test plan

- [x] `pnpm test` — 全85テストパス
- [x] `pnpm lint` — パス
- [x] `pnpm test:coverage` — Statements 81.96%
- [ ] CI 全チェック green を確認

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)