### PR TITLE
refactor: データモデルに BaseFortune + FortuneType を導入 (#322)

### DIFF
--- a/app/__tests__/index.test.tsx
+++ b/app/__tests__/index.test.tsx
@@ -13,6 +13,7 @@ jest.mock("../../hooks/useOmikujiLogic", () => ({
   useOmikujiLogic: () => ({
     fortune: {
       id: "fortune-id",
+      type: "omikuji",
       level: "daikichi",
       messageIndex: 0,
       image: { uri: "test.png" },

--- a/components/design-system/__tests__/PaperResultCard.test.tsx
+++ b/components/design-system/__tests__/PaperResultCard.test.tsx
@@ -60,6 +60,7 @@ jest.spyOn(Share, "share").mockImplementation(() => Promise.resolve({ action: "s
 describe("PaperResultCard", () => {
   const mockFortune: OmikujiResult = {
     id: "test-id",
+    type: "omikuji",
     level: "daikichi",
     messageIndex: 0,
     image: { uri: "test.png" },

--- a/types/__tests__/omikuji.test.ts
+++ b/types/__tests__/omikuji.test.ts
@@ -1,0 +1,45 @@
+import { isOmikujiResult, OmikujiResult, FortuneResult } from "../omikuji";
+
+describe("omikuji type guards", () => {
+  const omikujiResult: OmikujiResult = {
+    id: "test-id",
+    type: "omikuji",
+    level: "daikichi",
+    messageIndex: 0,
+    image: { uri: "test.png" },
+    color: "#FFD700",
+    createdAt: 1234567890,
+  };
+
+  describe("isOmikujiResult", () => {
+    it("returns true for omikuji type", () => {
+      expect(isOmikujiResult(omikujiResult)).toBe(true);
+    });
+
+    it("narrows type correctly for omikuji result", () => {
+      const result: FortuneResult = omikujiResult;
+      if (isOmikujiResult(result)) {
+        // Type should be narrowed to OmikujiResult
+        expect(result.level).toBe("daikichi");
+        expect(result.messageIndex).toBe(0);
+      } else {
+        fail("Expected omikuji result");
+      }
+    });
+  });
+
+  describe("OmikujiResult", () => {
+    it("has required BaseFortune fields", () => {
+      expect(omikujiResult.id).toBeDefined();
+      expect(omikujiResult.type).toBe("omikuji");
+      expect(omikujiResult.createdAt).toBeDefined();
+    });
+
+    it("has required omikuji-specific fields", () => {
+      expect(omikujiResult.level).toBeDefined();
+      expect(omikujiResult.messageIndex).toBeDefined();
+      expect(omikujiResult.image).toBeDefined();
+      expect(omikujiResult.color).toBeDefined();
+    });
+  });
+});

--- a/types/omikuji.ts
+++ b/types/omikuji.ts
@@ -1,5 +1,21 @@
 import { ImageSourcePropType } from "react-native";
 
+/**
+ * 占い種別の判別子。
+ * 新しい占い種別を追加する場合はここに追加し、対応する結果型を定義する。
+ */
+export type FortuneType = "omikuji";
+
+/**
+ * すべての占い結果の基底型。
+ * 共通フィールド（id, type, createdAt）を持ち、type で具象型を判別する。
+ */
+export interface BaseFortune {
+  id: string;
+  type: FortuneType;
+  createdAt: number;
+}
+
 export type FortuneLevel =
   | "daikichi"
   | "chukichi"
@@ -9,11 +25,29 @@ export type FortuneLevel =
   | "kyo"
   | "daikyo";
 
-export interface OmikujiResult {
-  id: string; // Unique ID for history
+/**
+ * おみくじの結果。
+ * BaseFortune を拡張し、おみくじ固有のフィールドを持つ。
+ */
+export interface OmikujiResult extends BaseFortune {
+  type: "omikuji";
   level: FortuneLevel;
   messageIndex: number; // Index of the message in fortune.messages.[level]
   image: ImageSourcePropType; // Main result illustration
   color: string; // Theme color
-  createdAt: number; // Timestamp
+}
+
+/**
+ * すべての占い結果を表すユニオン型。
+ * 将来、タロット等が追加される場合にここに追加する。
+ */
+export type FortuneResult = OmikujiResult;
+
+// --- Type guards ---
+
+/**
+ * 結果がおみくじ種別かを判定する型ガード。
+ */
+export function isOmikujiResult(result: FortuneResult): result is OmikujiResult {
+  return result.type === "omikuji";
 }

--- a/utils/HistoryStorage.ts
+++ b/utils/HistoryStorage.ts
@@ -1,13 +1,30 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { OmikujiResult } from "../types/omikuji";
+import { FortuneResult, OmikujiResult } from "../types/omikuji";
 
 const HISTORY_KEY = "omikuji_history_v2"; // Changed key to avoid conflict with old schema
 const LAST_DRAW_DATE_KEY = "omikuji_last_draw_date";
 
 const MAX_HISTORY_ITEMS = 50;
 
-// Alias for clarity, but it is just OmikujiResult now
-export type HistoryEntry = OmikujiResult;
+/**
+ * 履歴エントリの型。
+ * 現状はおみくじのみだが、将来は他の占い種別（タロット等）も受け入れる。
+ */
+export type HistoryEntry = FortuneResult;
+
+/**
+ * レガシー履歴データ（type フィールドがない古いデータ）を
+ * 新しい BaseFortune 形式にマイグレートする。
+ */
+function migrateLegacyEntry(raw: unknown): HistoryEntry | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const entry = raw as Partial<OmikujiResult> & { type?: string };
+  if (!entry.id || !entry.level || typeof entry.createdAt !== "number") return null;
+  return {
+    ...entry,
+    type: entry.type === "omikuji" ? "omikuji" : "omikuji",
+  } as OmikujiResult;
+}
 
 export function getTodayString(): string {
   const now = new Date();
@@ -20,7 +37,13 @@ export function getTodayString(): string {
 export async function getHistory(): Promise<HistoryEntry[]> {
   try {
     const jsonValue = await AsyncStorage.getItem(HISTORY_KEY);
-    return jsonValue != null ? JSON.parse(jsonValue) : [];
+    if (jsonValue == null) return [];
+    const rawEntries = JSON.parse(jsonValue);
+    if (!Array.isArray(rawEntries)) return [];
+    // Legacy エントリ（type フィールドなし）もマイグレートして読み込む
+    return rawEntries
+      .map(migrateLegacyEntry)
+      .filter((entry): entry is HistoryEntry => entry !== null);
   } catch (error) {
     console.error("Failed to load history:", error);
     return [];
@@ -30,7 +53,7 @@ export async function getHistory(): Promise<HistoryEntry[]> {
 /**
  * 履歴に新しいエントリを追加する
  */
-export async function addHistoryEntry(result: OmikujiResult): Promise<void> {
+export async function addHistoryEntry(result: FortuneResult): Promise<void> {
   try {
     const history = await getHistory();
     // 最新のものが先頭に来るように追加し、50件に制限

--- a/utils/__tests__/HistoryStorage.test.ts
+++ b/utils/__tests__/HistoryStorage.test.ts
@@ -21,6 +21,7 @@ const LAST_DRAW_DATE_KEY = "omikuji_last_draw_date";
 const mockHistoryData: HistoryEntry[] = [
   {
     id: "1",
+    type: "omikuji",
     level: "daikichi",
     messageIndex: 0,
     image: { uri: "image" },
@@ -59,6 +60,7 @@ describe("HistoryStorage", () => {
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(mockHistoryData));
     const newEntry: HistoryEntry = {
       id: "2",
+      type: "omikuji",
       level: "kichi",
       messageIndex: 1,
       image: { uri: "image2" },

--- a/utils/omikujiLogic.ts
+++ b/utils/omikujiLogic.ts
@@ -32,6 +32,7 @@ export const drawOmikuji = (): OmikujiResult => {
   // 5. Construct Result
   return {
     id: Crypto.randomUUID(),
+    type: "omikuji",
     level: selectedData.level,
     messageIndex,
     image: selectedData.image,


### PR DESCRIPTION
## Summary

Issue #322 対応。将来の占い種別追加（#175 占いメニュー、#176 タロット等）に備えて、占い結果の型構造を拡張可能にした。

## 変更内容

### `types/omikuji.ts`
- `FortuneType` 判別子型を新規定義（現状は `"omikuji"` のみ）
- `BaseFortune` 基底インターフェースを新規定義（`id` / `type` / `createdAt`）
- `OmikujiResult` を `BaseFortune` 拡張に変更（`type: "omikuji"` フィールド追加）
- `FortuneResult` ユニオン型を新規定義（現状は `OmikujiResult` のみ）
- `isOmikujiResult` 型ガード関数を追加

### `utils/omikujiLogic.ts`
- `drawOmikuji` の返却値に `type: "omikuji"` を追加

### `utils/HistoryStorage.ts`
- `HistoryEntry` を `FortuneResult` に変更（複数占い種別の履歴に対応）
- `addHistoryEntry` の引数型を `FortuneResult` に拡張
- `getHistory` に `migrateLegacyEntry` を追加し、`type` なしの旧データも読み込める
- **既存ユーザーのデータ互換性を保証**

### テスト
- `types/__tests__/omikuji.test.ts`: 新規（型ガード・型構造のテスト 4件）
- 既存テストのモックデータに `type: "omikuji"` を追加

## 設計方針

- **最小差分で拡張可能性を確保**（現時点でタロット等の型は追加しない）
- ディスクリミナントユニオンで型安全な判別
- 既存ストレージデータの後方互換性を `migrateLegacyEntry` で維持
- 将来 Issue #175/#176 着手時は、型追加とハンドラー登録のみで拡張可能

## 拡張例（将来の実装時）

```typescript
// 将来タロット追加時の流れ
export type FortuneType = "omikuji" | "tarot";

export interface TarotResult extends BaseFortune {
  type: "tarot";
  cardName: string;
  isReversed: boolean;
}

export type FortuneResult = OmikujiResult | TarotResult;

export function isTarotResult(result: FortuneResult): result is TarotResult {
  return result.type === "tarot";
}
```

## Test plan

- [x] `pnpm test` — 18 suites, 88 tests all passed
- [x] `pnpm lint` — パス
- [x] `pnpm exec tsc --noEmit` — パス
- [ ] CI 全チェック green を確認

## 関連

- Part of Epic #174（占い要素導入の型基盤）
- Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)