### PR TITLE
refactor: design-system 層から business logic 依存を解消 (#321)

### DIFF
--- a/components/design-system/HistoryItemCard.tsx
+++ b/components/design-system/HistoryItemCard.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { Text, View } from "react-native";
-import { useTranslation } from "react-i18next";
 import { HistoryEntry } from "../../utils/HistoryStorage";
-import { getFortuneText } from "../../utils/getFortuneText";
 import { getComponentTokens, getStringToken } from "../../design-system";
 import { SurfaceCard } from "./SurfaceCard";
 
@@ -19,22 +17,17 @@ function formatDate(timestamp: number): string {
 
 interface HistoryItemCardProps {
   item: HistoryEntry;
+  fortuneTitle: string;
+  fortuneMessage: string;
 }
 
-export function HistoryItemCard({ item }: HistoryItemCardProps) {
-  const { t } = useTranslation();
+export function HistoryItemCard({ item, fortuneTitle, fortuneMessage }: HistoryItemCardProps) {
   const tokens = getComponentTokens<{
     metaColor: string;
     bodyColor: string;
   }>("history.item");
   const ritualBodyFont = getStringToken("primitive.typography.family.ritualBody");
   const fortuneColor = getStringToken(`semantic.fortune.level.${item.level}`);
-
-  const { title: fortuneTitle, message: fortuneMessage } = getFortuneText(
-    t,
-    item.level,
-    item.messageIndex
-  );
 
   return (
     <SurfaceCard variant="glassCard">

--- a/components/design-system/PaperResultCard.tsx
+++ b/components/design-system/PaperResultCard.tsx
@@ -12,10 +12,7 @@ import { captureRef } from "react-native-view-shot";
 import * as Haptics from "expo-haptics";
 import { useTranslation } from "react-i18next";
 import { triggerHaptic } from "../../utils/haptics";
-import { DETAIL_KEYS } from "../../data/omikujiData";
 import { OmikujiResult } from "../../types/omikuji";
-import { buildShareText } from "../../utils/buildShareText";
-import { getFortuneText } from "../../utils/getFortuneText";
 import { Button } from "./Button";
 import { MotionView } from "./MotionView";
 import { SurfaceCard } from "./SurfaceCard";
@@ -27,13 +24,31 @@ const ANIMATION_TIMING = {
   keep: 800,
 };
 
+export interface FortuneDetailEntry {
+  key: string;
+  label: string;
+  value: string;
+}
+
 interface PaperResultCardProps {
   fortune: OmikujiResult;
+  fortuneTitle: string;
+  fortuneMessage: string;
+  detailEntries: FortuneDetailEntry[];
+  shareText: string;
   onReset: () => void;
   reducedMotion?: boolean;
 }
 
-export function PaperResultCard({ fortune, onReset, reducedMotion = false }: PaperResultCardProps) {
+export function PaperResultCard({
+  fortune,
+  fortuneTitle,
+  fortuneMessage,
+  detailEntries,
+  shareText,
+  onReset,
+  reducedMotion = false,
+}: PaperResultCardProps) {
   const { height } = useWindowDimensions();
   const cardRef = useRef<View>(null);
   const tieTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -61,12 +76,6 @@ export function PaperResultCard({ fortune, onReset, reducedMotion = false }: Pap
       if (keepTimerRef.current) clearTimeout(keepTimerRef.current);
     };
   }, []);
-
-  const { title: fortuneTitle, message: fortuneMessage } = getFortuneText(
-    t,
-    fortune.level,
-    fortune.messageIndex
-  );
 
   const handleTie = useCallback(() => {
     if (exitAnimation) return;
@@ -106,10 +115,7 @@ export function PaperResultCard({ fortune, onReset, reducedMotion = false }: Pap
 
   const handleShare = async () => {
     try {
-      const message = buildShareText({
-        title: fortuneTitle,
-        description: fortuneMessage,
-      });
+      const message = shareText;
 
       if (Platform.OS === "web") {
         try {
@@ -345,9 +351,9 @@ export function PaperResultCard({ fortune, onReset, reducedMotion = false }: Pap
                   gap: isCompactHeight ? 10 : 14,
                 }}
               >
-                {DETAIL_KEYS.map((key) => (
+                {detailEntries.map((entry) => (
                   <View
-                    key={key}
+                    key={entry.key}
                     style={{
                       flexDirection: "row",
                       gap: 12,
@@ -361,10 +367,10 @@ export function PaperResultCard({ fortune, onReset, reducedMotion = false }: Pap
                         fontWeight: "700",
                       }}
                     >
-                      {t(`fortune.detailLabels.${key}`)}
+                      {entry.label}
                     </Text>
                     <Text style={{ flex: 1, color: resultTokens.bodyColor, lineHeight: 23 }}>
-                      {t(`fortune.details.${fortune.level}.${key}`)}
+                      {entry.value}
                     </Text>
                   </View>
                 ))}

--- a/components/design-system/__tests__/PaperResultCard.test.tsx
+++ b/components/design-system/__tests__/PaperResultCard.test.tsx
@@ -68,6 +68,25 @@ describe("PaperResultCard", () => {
     createdAt: 1234567890,
   };
 
+  const mockDetailEntries = [
+    { key: "wish", label: "願望", value: "思うがままに叶うでしょう。" },
+    { key: "waitingPerson", label: "待人", value: "音信あり。すぐに来ます。" },
+  ];
+
+  const renderCard = (overrides: Partial<React.ComponentProps<typeof PaperResultCard>> = {}) =>
+    render(
+      <PaperResultCard
+        fortune={mockFortune}
+        fortuneTitle="大吉"
+        fortuneMessage="最高の運気です。新しいことに挑戦するチャンス！"
+        detailEntries={mockDetailEntries}
+        shareText="シェアテキスト：大吉"
+        onReset={jest.fn()}
+        reducedMotion
+        {...overrides}
+      />
+    );
+
   let consoleErrorSpy: jest.SpyInstance;
 
   beforeEach(() => {
@@ -81,9 +100,7 @@ describe("PaperResultCard", () => {
 
   it("handleTie sets exit animation and shows tied complete after timeout", async () => {
     jest.useFakeTimers();
-    const { getByText, queryByText } = render(
-      <PaperResultCard fortune={mockFortune} onReset={jest.fn()} reducedMotion />
-    );
+    const { getByText, queryByText } = renderCard();
 
     fireEvent.press(getByText("結ぶ"));
 
@@ -101,9 +118,7 @@ describe("PaperResultCard", () => {
   it("handleKeep calls onReset after animation", () => {
     jest.useFakeTimers();
     const onReset = jest.fn();
-    const { getByText } = render(
-      <PaperResultCard fortune={mockFortune} onReset={onReset} reducedMotion />
-    );
+    const { getByText } = renderCard({ onReset });
 
     fireEvent.press(getByText("持ち帰る"));
 
@@ -117,9 +132,7 @@ describe("PaperResultCard", () => {
   });
 
   it("falls back to text sharing when image capture fails", async () => {
-    const { getByText } = render(
-      <PaperResultCard fortune={mockFortune} onReset={jest.fn()} reducedMotion />
-    );
+    const { getByText } = renderCard();
 
     fireEvent.press(getByText("シェア"));
 

--- a/components/patterns/HistoryListPattern.tsx
+++ b/components/patterns/HistoryListPattern.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { FlatList, View } from "react-native";
+import { useTranslation } from "react-i18next";
 import { HistoryEntry } from "../../utils/HistoryStorage";
+import { getFortuneText } from "../../utils/getFortuneText";
 import { HistoryEmptyState } from "../design-system/HistoryEmptyState";
 import { HistoryItemCard } from "../design-system/HistoryItemCard";
 
@@ -9,6 +11,8 @@ interface HistoryListPatternProps {
 }
 
 export function HistoryListPattern({ history }: HistoryListPatternProps) {
+  const { t } = useTranslation();
+
   if (history.length === 0) {
     return <HistoryEmptyState />;
   }
@@ -17,11 +21,14 @@ export function HistoryListPattern({ history }: HistoryListPatternProps) {
     <FlatList
       data={history}
       keyExtractor={(item) => item.id}
-      renderItem={({ item }) => (
-        <View style={{ marginBottom: 12 }}>
-          <HistoryItemCard item={item} />
-        </View>
-      )}
+      renderItem={({ item }) => {
+        const { title, message } = getFortuneText(t, item.level, item.messageIndex);
+        return (
+          <View style={{ marginBottom: 12 }}>
+            <HistoryItemCard item={item} fortuneTitle={title} fortuneMessage={message} />
+          </View>
+        );
+      }}
       showsVerticalScrollIndicator={false}
       contentContainerStyle={{ paddingBottom: 24 }}
     />

--- a/components/patterns/ResultPattern.tsx
+++ b/components/patterns/ResultPattern.tsx
@@ -1,6 +1,10 @@
-import React from "react";
+import React, { useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { OmikujiResult } from "../../types/omikuji";
-import { PaperResultCard } from "../design-system/PaperResultCard";
+import { DETAIL_KEYS } from "../../data/omikujiData";
+import { buildShareText } from "../../utils/buildShareText";
+import { getFortuneText } from "../../utils/getFortuneText";
+import { FortuneDetailEntry, PaperResultCard } from "../design-system/PaperResultCard";
 
 interface ResultPatternProps {
   fortune: OmikujiResult;
@@ -9,5 +13,37 @@ interface ResultPatternProps {
 }
 
 export function ResultPattern({ fortune, onReset, reducedMotion = false }: ResultPatternProps) {
-  return <PaperResultCard fortune={fortune} onReset={onReset} reducedMotion={reducedMotion} />;
+  const { t } = useTranslation();
+
+  const { title: fortuneTitle, message: fortuneMessage } = useMemo(
+    () => getFortuneText(t, fortune.level, fortune.messageIndex),
+    [t, fortune.level, fortune.messageIndex]
+  );
+
+  const detailEntries = useMemo<FortuneDetailEntry[]>(
+    () =>
+      DETAIL_KEYS.map((key) => ({
+        key,
+        label: t(`fortune.detailLabels.${key}`),
+        value: t(`fortune.details.${fortune.level}.${key}`),
+      })),
+    [t, fortune.level]
+  );
+
+  const shareText = useMemo(
+    () => buildShareText({ title: fortuneTitle, description: fortuneMessage }),
+    [fortuneTitle, fortuneMessage]
+  );
+
+  return (
+    <PaperResultCard
+      fortune={fortune}
+      fortuneTitle={fortuneTitle}
+      fortuneMessage={fortuneMessage}
+      detailEntries={detailEntries}
+      shareText={shareText}
+      onReset={onReset}
+      reducedMotion={reducedMotion}
+    />
+  );
 }


### PR DESCRIPTION
## Summary

Issue #321 対応。design-system コンポーネントが utils のビジネスロジック（`getFortuneText` / `buildShareText` / `DETAIL_KEYS` 経由の詳細取得）に直接依存していた構造を修正し、domain data を props 経由で受け取る形にした。

## 変更内容

### `components/design-system/HistoryItemCard.tsx`
- `useTranslation`, `getFortuneText` の import を削除
- `fortuneTitle` / `fortuneMessage` を props で受け取る

### `components/design-system/PaperResultCard.tsx`
- `buildShareText`, `getFortuneText`, `DETAIL_KEYS` の import を削除
- 新しい props: `fortuneTitle` / `fortuneMessage` / `detailEntries` / `shareText`
- `FortuneDetailEntry` 型を export
- 詳細レンダリングは事前計算された `detailEntries` を使用
- 共通 UI 翻訳（tie/keep/share 等）の `useTranslation` は維持

### `components/patterns/ResultPattern.tsx`
- i18n 翻訳と business logic を集約
- `useMemo` で `fortuneTitle` / `fortuneMessage` / `detailEntries` / `shareText` を計算
- `PaperResultCard` に props として渡す

### `components/patterns/HistoryListPattern.tsx`
- `useTranslation` と `getFortuneText` を pattern 層に移動
- 各アイテムに対して fortune データを計算して `HistoryItemCard` に渡す

## 設計原則の適用

- **design-system 層** = プレゼンテーション専用（props で表示データを受け取る）
- **pattern 層** = business logic と i18n の集約地点
- 境界が明確になり、design-system コンポーネントのテスト容易性が向上

## Test plan

- [x] `pnpm test` — 19 suites, 97 tests all passed
- [x] `pnpm lint` — パス
- [x] `pnpm exec tsc --noEmit` — パス
- [ ] CI 全チェック green を確認

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)