### PR TITLE
fix: app.json version を 1.2.0 に更新（リリース漏れ修正）

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,65 +1,65 @@
 {
-    "expo": {
-        "name": "デジタルおみくじ",
-        "slug": "digital-omikuji",
-        "version": "1.1.0",
-        "orientation": "portrait",
-        "userInterfaceStyle": "light",
-        "icon": "./assets/icon.png",
-        "splash": {
-            "image": "./assets/splash.png",
-            "resizeMode": "contain",
-            "backgroundColor": "#dc2626"
-        },
-        "ios": {
-            "supportsTablet": true,
-            "bundleIdentifier": "com.s977043.digitalomikuji",
-            "icon": "./assets/icon.png",
-            "infoPlist": {
-                "CFBundleDisplayName": "デジタルおみくじ",
-                "NSPhotoLibraryUsageDescription": "おみくじ結果を画像として保存するために写真ライブラリへのアクセスが必要です",
-                "NSPhotoLibraryAddUsageDescription": "おみくじ結果を画像として保存するために写真ライブラリへの書き込みアクセスが必要です",
-                "ITSAppUsesNonExemptEncryption": false
-            }
-        },
-        "android": {
-            "package": "com.s977043.digitalomikuji",
-            "adaptiveIcon": {
-                "foregroundImage": "./assets/adaptive-icon.png",
-                "backgroundColor": "#dc2626"
-            },
-            "permissions": [
-                "android.permission.WRITE_EXTERNAL_STORAGE",
-                "android.permission.READ_EXTERNAL_STORAGE"
-            ]
-        },
-        "web": {
-            "bundler": "metro",
-            "output": "static",
-            "favicon": "./assets/favicon.png"
-        },
-        "plugins": [
-            "expo-router",
-            "expo-splash-screen",
-            [
-                "@sentry/react-native/expo",
-                {
-                    "organization": "mine-take",
-                    "project": "digital-omikuji",
-                    "url": "https://sentry.io/"
-                }
-            ]
-        ],
-        "extra": {
-            "eas": {
-                "projectId": "bb6d2a55-da96-4419-8ac9-f8133d4d9fc6"
-            }
-        },
-        "runtimeVersion": {
-            "policy": "appVersion"
-        },
-        "updates": {
-            "url": "https://u.expo.dev/bb6d2a55-da96-4419-8ac9-f8133d4d9fc6"
+  "expo": {
+    "name": "デジタルおみくじ",
+    "slug": "digital-omikuji",
+    "version": "1.2.0",
+    "orientation": "portrait",
+    "userInterfaceStyle": "light",
+    "icon": "./assets/icon.png",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#dc2626"
+    },
+    "ios": {
+      "supportsTablet": true,
+      "bundleIdentifier": "com.s977043.digitalomikuji",
+      "icon": "./assets/icon.png",
+      "infoPlist": {
+        "CFBundleDisplayName": "デジタルおみくじ",
+        "NSPhotoLibraryUsageDescription": "おみくじ結果を画像として保存するために写真ライブラリへのアクセスが必要です",
+        "NSPhotoLibraryAddUsageDescription": "おみくじ結果を画像として保存するために写真ライブラリへの書き込みアクセスが必要です",
+        "ITSAppUsesNonExemptEncryption": false
+      }
+    },
+    "android": {
+      "package": "com.s977043.digitalomikuji",
+      "adaptiveIcon": {
+        "foregroundImage": "./assets/adaptive-icon.png",
+        "backgroundColor": "#dc2626"
+      },
+      "permissions": [
+        "android.permission.WRITE_EXTERNAL_STORAGE",
+        "android.permission.READ_EXTERNAL_STORAGE"
+      ]
+    },
+    "web": {
+      "bundler": "metro",
+      "output": "static",
+      "favicon": "./assets/favicon.png"
+    },
+    "plugins": [
+      "expo-router",
+      "expo-splash-screen",
+      [
+        "@sentry/react-native/expo",
+        {
+          "organization": "mine-take",
+          "project": "digital-omikuji",
+          "url": "https://sentry.io/"
         }
+      ]
+    ],
+    "extra": {
+      "eas": {
+        "projectId": "bb6d2a55-da96-4419-8ac9-f8133d4d9fc6"
+      }
+    },
+    "runtimeVersion": {
+      "policy": "appVersion"
+    },
+    "updates": {
+      "url": "https://u.expo.dev/bb6d2a55-da96-4419-8ac9-f8133d4d9fc6"
     }
+  }
 }


### PR DESCRIPTION
## Summary

PR #328 のリリース PR で `package.json` のみバージョンを更新していたが、`app.json` のバージョンが 1.1.0 のままだった。

## 問題

Expo/React Native は `Constants.expoConfig.version` を **`app.json` から** 読むため、以下が v1.1.0 のままになっていた:
- UI の VersionDisplay コンポーネント表示
- Sentry のリリースタグ（`initializeSentry` 内）

## 修正内容

- `app.json` の `version` を 1.1.0 → 1.2.0 に更新
- 同時に既存のインデント不整合（4-space）を Prettier 設定（tabWidth: 2）に自動整形

## Test plan

- [x] `pnpm test` — 全115テストパス
- [x] `pnpm lint` — パス
- [ ] CI 全チェック green を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)