### PR TITLE
chore(ci): Setup composite action 化で重複削減

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -1,0 +1,29 @@
+name: "Setup Node & pnpm environment"
+description: "Common setup for pnpm, Node.js, and project dependencies"
+
+inputs:
+  node-version:
+    description: "Node.js version to install"
+    required: false
+    default: "20"
+  install-dependencies:
+    description: "Whether to run pnpm install --frozen-lockfile"
+    required: false
+    default: "true"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v5
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: "pnpm"
+
+    - name: Install dependencies
+      if: inputs.install-dependencies == 'true'
+      shell: bash
+      run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: "20"
   install-dependencies:
-    description: "Whether to run pnpm install --frozen-lockfile"
+    description: "Whether to run pnpm install --frozen-lockfile --prefer-offline"
     required: false
     default: "true"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,17 +69,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
 
       - name: Run
         run: ${{ matrix.command }}

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -21,13 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
         with:
-          node-version: 20
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+          install-dependencies: "false"
 
       - name: Install Vercel CLI
         run: pnpm add -g vercel@latest

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -50,16 +50,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
 
       # Playwright ブラウザのキャッシュ (package.jsonからバージョン取得で安定化)
       - name: Get Playwright version

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,16 +46,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
 
       - name: Install Maestro
         run: |
@@ -126,16 +118,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
 
       - name: Install Maestro
         run: |


### PR DESCRIPTION
## Summary

4 つのワークフロー（ci / e2e-web / e2e / deploy-vercel）で重複していた Node/pnpm セットアップを composite action に集約。

## 新規

### `.github/actions/setup-environment/action.yml`

```yaml
name: "Setup Node & pnpm environment"
inputs:
  node-version: { default: "20" }
  install-dependencies: { default: "true" }
runs:
  using: composite
  steps:
    - uses: pnpm/action-setup@v5
    - uses: actions/setup-node@v6
      with:
        node-version: ${{ inputs.node-version }}
        cache: pnpm
    - if: inputs.install-dependencies == 'true'
      run: pnpm install --frozen-lockfile --prefer-offline
```

## 各ワークフローの更新

| ファイル | Before | After |
|---|---|---|
| `ci.yml` | 4 ステップ | 1 ステップ |
| `e2e-web.yml` | 4 ステップ | 1 ステップ |
| `e2e.yml` (android) | 4 ステップ | 1 ステップ |
| `e2e.yml` (ios) | 4 ステップ | 1 ステップ |
| `deploy-vercel.yml` | 3 ステップ | 1 ステップ (install-deps なし) |

`deploy-vercel.yml` は Vercel CLI のグローバルインストールが必要なため、`install-dependencies: "false"` で pnpm install をスキップする構成にしている。

## 効果

- **削除**: 47 行 / **追加**: 40 行（composite action 含む）
- Node/pnpm バージョンの一元管理
- 将来の setup ロジック追加が 1 箇所で済む

## Test plan

- [x] `pnpm test` — 21 suites, 115 tests all passed (アプリコード変更なし)
- [x] `pnpm lint` — パス
- [ ] CI 全チェック green を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)