### PR TITLE
refactor: FortuneLevel トークンを型安全 helper に集約

### DIFF
--- a/components/design-system/HistoryItemCard.tsx
+++ b/components/design-system/HistoryItemCard.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { Text, View } from "react-native";
 import { HistoryEntry } from "../../utils/HistoryStorage";
 import { getComponentTokens, getStringToken } from "../../design-system";
+import { getFortuneLevelColor } from "../../design-system/fortuneTokens";
+import { isOmikujiResult } from "../../types/omikuji";
 import { SurfaceCard } from "./SurfaceCard";
 
 function formatDate(timestamp: number): string {
@@ -27,7 +29,8 @@ export function HistoryItemCard({ item, fortuneTitle, fortuneMessage }: HistoryI
     bodyColor: string;
   }>("history.item");
   const ritualBodyFont = getStringToken("primitive.typography.family.ritualBody");
-  const fortuneColor = getStringToken(`semantic.fortune.level.${item.level}`);
+  // 現状は omikuji 種別のみだが、将来の占い種別追加に備えて型ガードで分岐
+  const fortuneColor = isOmikujiResult(item) ? getFortuneLevelColor(item.level) : "#FFFFFF";
 
   return (
     <SurfaceCard variant="glassCard">

--- a/components/design-system/HistoryItemCard.tsx
+++ b/components/design-system/HistoryItemCard.tsx
@@ -30,7 +30,10 @@ export function HistoryItemCard({ item, fortuneTitle, fortuneMessage }: HistoryI
   }>("history.item");
   const ritualBodyFont = getStringToken("primitive.typography.family.ritualBody");
   // 現状は omikuji 種別のみだが、将来の占い種別追加に備えて型ガードで分岐
-  const fortuneColor = isOmikujiResult(item) ? getFortuneLevelColor(item.level) : "#FFFFFF";
+  // omikuji 以外のフォールバック色は semantic トークンから取得（raw HEX は使わない）
+  const fortuneColor = isOmikujiResult(item)
+    ? getFortuneLevelColor(item.level)
+    : getStringToken("semantic.text.primary");
 
   return (
     <SurfaceCard variant="glassCard">

--- a/components/design-system/PaperResultCard.tsx
+++ b/components/design-system/PaperResultCard.tsx
@@ -17,6 +17,7 @@ import { Button } from "./Button";
 import { MotionView } from "./MotionView";
 import { SurfaceCard } from "./SurfaceCard";
 import { getComponentTokens, getStringToken } from "../../design-system";
+import { getFortuneLevelColor } from "../../design-system/fortuneTokens";
 import { COMPACT_HEIGHT_BREAKPOINT } from "../../constants/layout";
 
 const ANIMATION_TIMING = {
@@ -63,7 +64,7 @@ export function PaperResultCard({
     trimColor: string;
     accentColor: string;
   }>("result.paperResult");
-  const fortuneColor = getStringToken(`semantic.fortune.level.${fortune.level}`);
+  const fortuneColor = getFortuneLevelColor(fortune.level);
   const isCompactHeight = height < COMPACT_HEIGHT_BREAKPOINT;
   const actionButtonStyle = {
     minHeight: isCompactHeight ? 48 : 56,

--- a/design-system/__tests__/fortuneTokens.test.ts
+++ b/design-system/__tests__/fortuneTokens.test.ts
@@ -1,5 +1,6 @@
 import { FortuneLevel } from "../../types/omikuji";
 import { getFortuneLevelColor } from "../fortuneTokens";
+import * as designSystem from "../index";
 
 describe("getFortuneLevelColor", () => {
   const levels: FortuneLevel[] = [
@@ -12,11 +13,30 @@ describe("getFortuneLevelColor", () => {
     "daikyo",
   ];
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it.each(levels)("returns a non-empty color string for %s", (level) => {
     const color = getFortuneLevelColor(level);
     expect(typeof color).toBe("string");
     expect(color.length).toBeGreaterThan(0);
   });
+
+  it.each(levels)(
+    "passes 'semantic.fortune.level.%s' to getStringToken (mapping correctness)",
+    (level) => {
+      // マッピングの正しさを検証: 各 FortuneLevel が正しいトークンパスに
+      // 紐づいていることを保証する（例: kyo が誤って kichi のトークンに紐づいた
+      // ような混線を検出できる）
+      const spy = jest.spyOn(designSystem, "getStringToken").mockReturnValue("#TESTCOLOR");
+
+      const result = getFortuneLevelColor(level);
+
+      expect(spy).toHaveBeenCalledWith(`semantic.fortune.level.${level}`);
+      expect(result).toBe("#TESTCOLOR");
+    }
+  );
 
   it("returns different colors for daikichi vs daikyo (sanity check)", () => {
     const daikichi = getFortuneLevelColor("daikichi");

--- a/design-system/__tests__/fortuneTokens.test.ts
+++ b/design-system/__tests__/fortuneTokens.test.ts
@@ -1,0 +1,26 @@
+import { FortuneLevel } from "../../types/omikuji";
+import { getFortuneLevelColor } from "../fortuneTokens";
+
+describe("getFortuneLevelColor", () => {
+  const levels: FortuneLevel[] = [
+    "daikichi",
+    "chukichi",
+    "shokichi",
+    "kichi",
+    "suekichi",
+    "kyo",
+    "daikyo",
+  ];
+
+  it.each(levels)("returns a non-empty color string for %s", (level) => {
+    const color = getFortuneLevelColor(level);
+    expect(typeof color).toBe("string");
+    expect(color.length).toBeGreaterThan(0);
+  });
+
+  it("returns different colors for daikichi vs daikyo (sanity check)", () => {
+    const daikichi = getFortuneLevelColor("daikichi");
+    const daikyo = getFortuneLevelColor("daikyo");
+    expect(daikichi).not.toBe(daikyo);
+  });
+});

--- a/design-system/fortuneTokens.ts
+++ b/design-system/fortuneTokens.ts
@@ -1,0 +1,33 @@
+import { FortuneLevel } from "../types/omikuji";
+import { getStringToken } from "./index";
+
+/**
+ * `FortuneLevel` ごとの `semantic.fortune.level.*` トークンパスマッピング。
+ *
+ * Record 型による完全性チェックにより、`FortuneLevel` ユニオンに新しいレベルを
+ * 追加した場合は、このマップにエントリを追加しないとコンパイルエラーになる。
+ */
+const FORTUNE_LEVEL_TOKEN_PATHS: Record<FortuneLevel, string> = {
+  daikichi: "semantic.fortune.level.daikichi",
+  chukichi: "semantic.fortune.level.chukichi",
+  shokichi: "semantic.fortune.level.shokichi",
+  kichi: "semantic.fortune.level.kichi",
+  suekichi: "semantic.fortune.level.suekichi",
+  kyo: "semantic.fortune.level.kyo",
+  daikyo: "semantic.fortune.level.daikyo",
+};
+
+/**
+ * 指定された `FortuneLevel` に対応する色トークンを返す。
+ *
+ * 文字列テンプレート（`semantic.fortune.level.${level}`）を直接 `getStringToken`
+ * に渡すよりも以下の利点がある:
+ *
+ * - **型安全**: `FortuneLevel` 以外の値を渡すとコンパイルエラー
+ * - **完全性**: 新しい `FortuneLevel` を追加すると `FORTUNE_LEVEL_TOKEN_PATHS`
+ *   マップにエントリ追加が必須になる
+ * - **トークンパス変更時の影響範囲が明確**: マップを 1 箇所変更すれば全コンポーネントに反映
+ */
+export function getFortuneLevelColor(level: FortuneLevel): string {
+  return getStringToken(FORTUNE_LEVEL_TOKEN_PATHS[level]);
+}


### PR DESCRIPTION
## Summary

`getStringToken(\`semantic.fortune.level.\${level}\`)` のような文字列テンプレートでトークン参照していたため、`FortuneLevel` 以外の値を渡しても TypeScript がエラーにならない問題があった。`Record<FortuneLevel, string>` で完全性保証された helper に集約。

## 新規

### `design-system/fortuneTokens.ts`

```typescript
const FORTUNE_LEVEL_TOKEN_PATHS: Record<FortuneLevel, string> = {
  daikichi: "semantic.fortune.level.daikichi",
  // ... 全 7 種
};

export function getFortuneLevelColor(level: FortuneLevel): string {
  return getStringToken(FORTUNE_LEVEL_TOKEN_PATHS[level]);
}
```

新しい `FortuneLevel` を追加するとマップにエントリ追加が必須となり、TypeScript が漏れを検出する。

### `design-system/__tests__/fortuneTokens.test.ts`

8 件のテスト（全 7 レベル + sanity check）

## 更新

### `components/design-system/HistoryItemCard.tsx`
- `isOmikujiResult` 型ガードで分岐（将来の占い種別追加に備える）
- `getFortuneLevelColor(item.level)` に置換

### `components/design-system/PaperResultCard.tsx`
- `getFortuneLevelColor(fortune.level)` に置換

## 効果

- **型安全**: `FortuneLevel` 以外の値を渡すとコンパイルエラー
- **完全性**: 新しい `FortuneLevel` 追加時にマップ更新が強制される
- **トークンパス変更時の影響範囲が明確**: マップを 1 箇所変更すれば全コンポーネントに反映

## Test plan

- [x] `pnpm test` — 26 suites, 136 tests all passed (+8 new)
- [x] `pnpm lint` — パス
- [x] `pnpm exec tsc --noEmit` — パス
- [ ] CI 全チェック green を確認

## 受け入れ条件

- [x] `getFortuneLevelColor()` が新規追加される
- [x] 2 コンポーネントが置換される
- [x] 全テスト pass、型チェック pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)