### PR TITLE
test: templates のテスト整備（HistoryScreenTemplate / DocumentScreenTemplate を 100%）

### DIFF
--- a/components/__tests__/DocumentScreenTemplate.test.tsx
+++ b/components/__tests__/DocumentScreenTemplate.test.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { Text } from "react-native";
+import { render } from "@testing-library/react-native";
+import { DocumentScreenTemplate } from "../templates/DocumentScreenTemplate";
+
+describe("DocumentScreenTemplate", () => {
+  it("renders header and children", () => {
+    const { getByText } = render(
+      <DocumentScreenTemplate header={<Text>ドキュメントヘッダー</Text>}>
+        <Text>本文セクション</Text>
+      </DocumentScreenTemplate>
+    );
+    expect(getByText("ドキュメントヘッダー")).toBeTruthy();
+    expect(getByText("本文セクション")).toBeTruthy();
+  });
+
+  it("renders multiple children", () => {
+    const { getByText } = render(
+      <DocumentScreenTemplate header={<Text>h</Text>}>
+        <Text>セクション1</Text>
+        <Text>セクション2</Text>
+      </DocumentScreenTemplate>
+    );
+    expect(getByText("セクション1")).toBeTruthy();
+    expect(getByText("セクション2")).toBeTruthy();
+  });
+
+  it("renders footer when provided", () => {
+    const { getByText } = render(
+      <DocumentScreenTemplate header={<Text>h</Text>} footer={<Text>ドキュメントフッター</Text>}>
+        <Text>body</Text>
+      </DocumentScreenTemplate>
+    );
+    expect(getByText("ドキュメントフッター")).toBeTruthy();
+  });
+
+  it("does not render footer when not provided", () => {
+    const { queryByText } = render(
+      <DocumentScreenTemplate header={<Text>h</Text>}>
+        <Text>body</Text>
+      </DocumentScreenTemplate>
+    );
+    expect(queryByText(/フッター/)).toBeNull();
+  });
+});

--- a/components/__tests__/ExperienceScreenTemplate.test.tsx
+++ b/components/__tests__/ExperienceScreenTemplate.test.tsx
@@ -90,13 +90,30 @@ describe("ExperienceScreenTemplate", () => {
   });
 
   it("renders only bottomLeftAction without right one", () => {
-    const { getByText, queryByText } = render(
+    // 同じ identifier で「渡すケース」と「渡さないケース」を rerender で検証し、
+    // 差分として右アクションが描画されない（消える）ことを確認する
+    const RIGHT_LABEL = "右アクション専用ラベル";
+    const { queryByText, rerender } = render(
+      <ExperienceScreenTemplate
+        topBar={<Text>header</Text>}
+        bottomLeftAction={<Text>左のみ</Text>}
+        bottomRightAction={<Text>{RIGHT_LABEL}</Text>}
+      >
+        <Text>body</Text>
+      </ExperienceScreenTemplate>
+    );
+    // 最初は両方描画される
+    expect(queryByText("左のみ")).toBeTruthy();
+    expect(queryByText(RIGHT_LABEL)).toBeTruthy();
+
+    // bottomRightAction を省略して再レンダリング
+    rerender(
       <ExperienceScreenTemplate topBar={<Text>header</Text>} bottomLeftAction={<Text>左のみ</Text>}>
         <Text>body</Text>
       </ExperienceScreenTemplate>
     );
-    expect(getByText("左のみ")).toBeTruthy();
-    expect(queryByText("右のみ")).toBeNull();
+    expect(queryByText("左のみ")).toBeTruthy();
+    expect(queryByText(RIGHT_LABEL)).toBeNull();
   });
 
   it("renders without topBar", () => {

--- a/components/__tests__/ExperienceScreenTemplate.test.tsx
+++ b/components/__tests__/ExperienceScreenTemplate.test.tsx
@@ -56,4 +56,55 @@ describe("ExperienceScreenTemplate", () => {
     expect(topBar?.props.accessibilityElementsHidden).toBe(false);
     expect(topBar?.props.importantForAccessibility).toBe("auto");
   });
+
+  it("renders children content", () => {
+    const { getByText } = render(
+      <ExperienceScreenTemplate topBar={<Text>header</Text>}>
+        <Text>本文コンテンツ</Text>
+      </ExperienceScreenTemplate>
+    );
+    expect(getByText("本文コンテンツ")).toBeTruthy();
+  });
+
+  it("renders footer when provided", () => {
+    const { getByText } = render(
+      <ExperienceScreenTemplate topBar={<Text>header</Text>} footer={<Text>フッター内容</Text>}>
+        <Text>body</Text>
+      </ExperienceScreenTemplate>
+    );
+    expect(getByText("フッター内容")).toBeTruthy();
+  });
+
+  it("renders bottomLeftAction and bottomRightAction", () => {
+    const { getByText } = render(
+      <ExperienceScreenTemplate
+        topBar={<Text>header</Text>}
+        bottomLeftAction={<Text>左アクション</Text>}
+        bottomRightAction={<Text>右アクション</Text>}
+      >
+        <Text>body</Text>
+      </ExperienceScreenTemplate>
+    );
+    expect(getByText("左アクション")).toBeTruthy();
+    expect(getByText("右アクション")).toBeTruthy();
+  });
+
+  it("renders only bottomLeftAction without right one", () => {
+    const { getByText, queryByText } = render(
+      <ExperienceScreenTemplate topBar={<Text>header</Text>} bottomLeftAction={<Text>左のみ</Text>}>
+        <Text>body</Text>
+      </ExperienceScreenTemplate>
+    );
+    expect(getByText("左のみ")).toBeTruthy();
+    expect(queryByText("右のみ")).toBeNull();
+  });
+
+  it("renders without topBar", () => {
+    const { getByText } = render(
+      <ExperienceScreenTemplate>
+        <Text>topBarなし</Text>
+      </ExperienceScreenTemplate>
+    );
+    expect(getByText("topBarなし")).toBeTruthy();
+  });
 });

--- a/components/__tests__/HistoryScreenTemplate.test.tsx
+++ b/components/__tests__/HistoryScreenTemplate.test.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { Text } from "react-native";
+import { render } from "@testing-library/react-native";
+import { HistoryScreenTemplate } from "../templates/HistoryScreenTemplate";
+
+describe("HistoryScreenTemplate", () => {
+  it("renders header and content", () => {
+    const { getByText } = render(
+      <HistoryScreenTemplate
+        header={<Text>履歴ヘッダー</Text>}
+        content={<Text>履歴コンテンツ</Text>}
+      />
+    );
+    expect(getByText("履歴ヘッダー")).toBeTruthy();
+    expect(getByText("履歴コンテンツ")).toBeTruthy();
+  });
+
+  it("renders footer when provided", () => {
+    const { getByText } = render(
+      <HistoryScreenTemplate
+        header={<Text>ヘッダー</Text>}
+        content={<Text>コンテンツ</Text>}
+        footer={<Text>履歴フッター</Text>}
+      />
+    );
+    expect(getByText("履歴フッター")).toBeTruthy();
+  });
+
+  it("does not render footer when not provided", () => {
+    const { queryByText } = render(
+      <HistoryScreenTemplate header={<Text>h</Text>} content={<Text>c</Text>} />
+    );
+    expect(queryByText(/フッター/)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

`components/templates` のテストは `ExperienceScreenTemplate` のみ存在しており、`HistoryScreenTemplate` / `DocumentScreenTemplate` にはテストがなかった。両者のテストを新規作成し、`ExperienceScreenTemplate` にも追加テストを 5 件加えた。

## 変更内容

### 新規: `HistoryScreenTemplate.test.tsx` (3件)
- header と content のレンダリング
- footer の有無による分岐
- **カバレッジ 100% 達成**

### 新規: `DocumentScreenTemplate.test.tsx` (4件)
- header と children のレンダリング
- 複数 children
- footer の有無による分岐
- **カバレッジ 100% 達成**

### 拡張: `ExperienceScreenTemplate.test.tsx` (5件追加 = 計 7件)
- children のレンダリング
- footer の表示
- bottomLeftAction / bottomRightAction の組み合わせ
- topBar 無しでのレンダリング

## カバレッジ結果

| ファイル | Before | After |
|---|---|---|
| `HistoryScreenTemplate.tsx` | 100% / 50% (Stmt/Branch) | **100% / 100%** |
| `DocumentScreenTemplate.tsx` | 100% / 50% | **100% / 100%** |
| `ExperienceScreenTemplate.tsx` | 23.63% / 39.32% | 23.63% / 39.32%* |

> *`ExperienceScreenTemplate.tsx` (250行) の未カバー部分は **Web 用 focus trap** (useEffect 内の DOM 操作、lines 27-29, 68-128)。jsdom 環境ではモック困難のため、完全な 80% 達成には `useFocusTrap` カスタムフックへの抽出が必要。これは大規模リファクタとなるため、別 PR / follow-up issue で対応予定。

## Test plan

- [x] `pnpm test` — 27 suites, 140 tests all passed (+12 new)
- [x] `pnpm lint` — パス
- [ ] CI 全チェック green を確認

## 受け入れ条件

- [x] HistoryScreenTemplate / DocumentScreenTemplate のテスト整備（100% 達成）
- [ ] ⚠️ templates 全体 80%（ExperienceScreenTemplate の Web focus trap が課題、follow-up）
- [x] 全テスト pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)