### PR TITLE
chore: gitignore に test/automation 生成物を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,11 @@ coverage/
 # Temporary artifacts
 pr_body.md
 pr*.json
+
+# Test / automation artifacts
+.playwright-mcp/
+test-results/
+playwright-report/
+
+# Claude Code runtime
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## 目的

未追跡の自動化生成物で作業ツリーが汚れる問題を解消する。

## 変更点

- \`.playwright-mcp/\` を除外
- \`test-results/\` \`playwright-report/\` を除外
- \`.claude/scheduled_tasks.lock\` を除外

## テスト

- 既存の追跡ファイルへ影響なし（追跡済みファイルに新規ignoreは影響しないため）
- \`git status\` クリーンを確認

## 影響範囲

- 開発者ローカル環境のみ（CI には影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)