### PR TITLE
refactor: SoundManager の再生遅延を解消

### DIFF
--- a/utils/SoundManager.ts
+++ b/utils/SoundManager.ts
@@ -2,6 +2,7 @@ import { Audio, AVPlaybackSource } from "expo-av";
 
 class SoundManager {
   private sounds: Map<string, Audio.Sound> = new Map();
+  private sources: Map<string, AVPlaybackSource> = new Map();
   private isReady: boolean = false;
   private volume: number = 1.0;
   private isMuted: boolean = false;
@@ -33,6 +34,7 @@ class SoundManager {
 
       if (status.isLoaded) {
         this.sounds.set(key, sound);
+        this.sources.set(key, source);
         return sound;
       } else {
         // Sound object created but not loaded; do not add to map
@@ -51,21 +53,33 @@ class SoundManager {
     }
     if (this.isMuted) return;
 
+    const sound = this.sounds.get(key);
+    if (!sound) {
+      console.warn(`Sound ${key} is not loaded (not in map).`);
+      return;
+    }
+
     try {
-      const sound = this.sounds.get(key);
-      if (!sound) {
-        console.warn(`Sound ${key} is not loaded (not in map).`);
+      await sound.replayAsync();
+    } catch (error) {
+      // 再生失敗時は一度だけ再ロード → replay を試みる。
+      // iOS のバックグラウンド復帰後など Sound オブジェクトが無効化されるケースを救済する。
+      const source = this.sources.get(key);
+      if (!source) {
+        console.error(`Failed to play sound ${key}:`, error);
         return;
       }
-
-      const status = await sound.getStatusAsync();
-      if (status.isLoaded) {
-        await sound.replayAsync();
-      } else {
-        console.warn(`Cannot play sound ${key}: it is in the map but not loaded. status:`, status);
+      try {
+        this.sounds.delete(key);
+        const reloaded = await this.loadSound(key, source);
+        if (reloaded) {
+          await reloaded.replayAsync();
+        } else {
+          console.error(`Failed to play sound ${key}:`, error);
+        }
+      } catch (retryError) {
+        console.error(`Failed to play sound ${key} after retry:`, retryError);
       }
-    } catch (error) {
-      console.error(`Failed to play sound ${key}:`, error);
     }
   }
 
@@ -103,6 +117,7 @@ class SoundManager {
       }
     }
     this.sounds.clear();
+    this.sources.clear();
   }
 }
 

--- a/utils/__tests__/SoundManager.test.ts
+++ b/utils/__tests__/SoundManager.test.ts
@@ -135,32 +135,35 @@ describe("SoundManager", () => {
     consoleSpy.mockRestore();
   });
 
-  it("warns if playing unloaded sound", async () => {
+  it("recovers from play error by reloading once", async () => {
     await soundManager.initialize();
     await soundManager.loadSound("test", { uri: "test" });
 
-    mockSound.getStatusAsync.mockResolvedValueOnce({ isLoaded: false });
-    const consoleSpy = jest.spyOn(console, "warn").mockImplementation();
+    // 1 回目の replay は失敗、フォールバックで createAsync + replay が成功するパス
+    mockSound.replayAsync.mockRejectedValueOnce(new Error("Play error"));
 
     await soundManager.playSound("test");
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Cannot play sound test"),
-      expect.anything()
-    );
-    consoleSpy.mockRestore();
+    // 再ロード（createAsync）→ replay の順で呼ばれる
+    expect(Audio.Sound.createAsync).toHaveBeenCalledTimes(2);
+    expect(mockSound.replayAsync).toHaveBeenCalledTimes(2);
   });
 
-  it("handles play sound error", async () => {
+  it("logs error when both initial play and retry fail", async () => {
     await soundManager.initialize();
     await soundManager.loadSound("test", { uri: "test" });
 
-    mockSound.replayAsync.mockRejectedValueOnce(new Error("Play error"));
+    mockSound.replayAsync
+      .mockRejectedValueOnce(new Error("Play error"))
+      .mockRejectedValueOnce(new Error("Retry error"));
     const consoleSpy = jest.spyOn(console, "error").mockImplementation();
 
     await soundManager.playSound("test");
 
-    expect(consoleSpy).toHaveBeenCalledWith("Failed to play sound test:", expect.any(Error));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Failed to play sound test after retry:",
+      expect.any(Error)
+    );
     consoleSpy.mockRestore();
   });
 


### PR DESCRIPTION
## 目的

シェイク効果音の再生遅延と、連続操作時のブツ切れ感を解消する。

## 変更点

- `utils/SoundManager.ts`
  - `playSound` から毎回の `getStatusAsync()` を削除し、`replayAsync` を即実行
  - `sources: Map<string, AVPlaybackSource>` を追加し、`loadSound` で source を保持
  - 再生失敗時のみ一度だけ再ロード → replay するフォールバックを追加（iOS バックグラウンド復帰等でオブジェクトが無効化されるケース救済）
  - `setMute` / `setVolume` / `unloadAll` は不変（`unloadAll` は `sources.clear()` のみ追加）
- `utils/__tests__/SoundManager.test.ts`
  - 削除済みコードパス依存の 1 件を撤去
  - recovery 挙動（成功 / 失敗）の 2 件を追加

## テスト結果

\`\`\`
$ pnpm exec jest utils/__tests__/SoundManager.test.ts
Tests:       18 passed, 18 total

$ pnpm exec jest
Tests:       210 passed, 210 total

$ pnpm exec tsc --noEmit  # 無出力 = 成功
$ pnpm lint               # 無出力 = 成功
\`\`\`

## 影響範囲

- シェイク時・リセット時の効果音再生のみ
- ネイティブ/Web 両方で同一コード（expo-av の Web サポートに依存）

## レビュー観点

- recovery 時に `loadSound` が内部的に `sources.set` を再実行するが、同一 key の再登録で冪等性が保たれているか
- `replayAsync` 失敗 → reload 成功 → 二度目の `replayAsync` も失敗、の二段失敗でログが 1 回だけ出るか

🤖 Generated with [Claude Code](https://claude.com/claude-code)