### PR TITLE
perf(web): MotionView に CSS transition を実装

### DIFF
--- a/components/design-system/MotionView.web.tsx
+++ b/components/design-system/MotionView.web.tsx
@@ -76,15 +76,7 @@ function buildAnimStyle(values: AnimDict | undefined): Record<string, string | n
 }
 
 export const MotionView = forwardRef<View, MotionViewProps>(function MotionView(
-  {
-    animate,
-    from,
-    transition,
-    exit: _exit,
-    state: _state,
-    style,
-    ...rest
-  },
+  { animate, from, transition, exit: _exit, state: _state, style, ...rest },
   ref
 ) {
   // from が指定された場合、初回レンダーは from 値、次フレームで animate 値へ遷移させる。
@@ -109,10 +101,6 @@ export const MotionView = forwardRef<View, MotionViewProps>(function MotionView(
   } as Record<string, string | number>;
 
   return (
-    <View
-      ref={ref}
-      style={[style, animStyle as object, transitionStyle as object]}
-      {...rest}
-    />
+    <View ref={ref} style={[style, animStyle as object, transitionStyle as object]} {...rest} />
   );
 });

--- a/components/design-system/MotionView.web.tsx
+++ b/components/design-system/MotionView.web.tsx
@@ -1,17 +1,118 @@
-import React, { forwardRef } from "react";
+import React, { forwardRef, useEffect, useState } from "react";
 import { View, ViewProps } from "react-native";
 
+/**
+ * Web 版 MotionView — CSS transition で Moti 相当の最小サブセットを実装する。
+ *
+ * サポート:
+ * - animate / from: opacity / translateX / translateY / scale / rotateZ
+ *   - 数値 or 文字列（"-8deg" など）を受け付ける
+ *   - 配列（キーフレーム）が渡された場合は末尾の値のみ使用（ループ/中間値は未対応）
+ * - transition: duration / delay（type/loop/repeatReverse は未対応、最終状態に即座に遷移）
+ *
+ * 未対応:
+ * - exit / state（将来 framer-motion 等を採用する場合に拡張）
+ * - loop / repeatReverse / keyframes の中間値
+ *
+ * ネイティブは Moti そのまま（MotionView.native.tsx 参照）。
+ */
+
+type AnimValue = number | string | (number | string)[];
+type AnimDict = {
+  opacity?: AnimValue;
+  translateX?: AnimValue;
+  translateY?: AnimValue;
+  scale?: AnimValue;
+  rotateZ?: AnimValue;
+};
+
+type TransitionDict = {
+  type?: "timing" | "spring";
+  duration?: number;
+  delay?: number;
+  loop?: boolean;
+  repeatReverse?: boolean;
+};
+
 type MotionViewProps = ViewProps & {
-  animate?: unknown;
-  from?: unknown;
-  transition?: unknown;
+  animate?: AnimDict;
+  from?: AnimDict;
+  transition?: TransitionDict;
+  // TODO: exit / state の Web サポートは framer-motion 採用時に追加する
   exit?: unknown;
   state?: unknown;
 };
 
+function pickLastValue(v: AnimValue | undefined): number | string | undefined {
+  if (v === undefined) return undefined;
+  if (Array.isArray(v)) return v[v.length - 1];
+  return v;
+}
+
+function toPxOrValue(v: number | string): string {
+  return typeof v === "number" ? `${v}px` : v;
+}
+
+function buildAnimStyle(values: AnimDict | undefined): Record<string, string | number> {
+  if (!values) return {};
+  const style: Record<string, string | number> = {};
+
+  const opacity = pickLastValue(values.opacity);
+  if (opacity !== undefined) style.opacity = Number(opacity);
+
+  const translateX = pickLastValue(values.translateX);
+  const translateY = pickLastValue(values.translateY);
+  const scale = pickLastValue(values.scale);
+  const rotateZ = pickLastValue(values.rotateZ);
+
+  const transforms: string[] = [];
+  if (translateX !== undefined) transforms.push(`translateX(${toPxOrValue(translateX)})`);
+  if (translateY !== undefined) transforms.push(`translateY(${toPxOrValue(translateY)})`);
+  if (scale !== undefined) transforms.push(`scale(${scale})`);
+  if (rotateZ !== undefined) transforms.push(`rotate(${rotateZ})`);
+  if (transforms.length > 0) style.transform = transforms.join(" ");
+
+  return style;
+}
+
 export const MotionView = forwardRef<View, MotionViewProps>(function MotionView(
-  { animate: _animate, from: _from, transition: _transition, exit: _exit, state: _state, ...rest },
+  {
+    animate,
+    from,
+    transition,
+    exit: _exit,
+    state: _state,
+    style,
+    ...rest
+  },
   ref
 ) {
-  return <View ref={ref} {...rest} />;
+  // from が指定された場合、初回レンダーは from 値、次フレームで animate 値へ遷移させる。
+  const [started, setStarted] = useState<boolean>(!from);
+
+  useEffect(() => {
+    if (!from) return;
+    const id = requestAnimationFrame(() => setStarted(true));
+    return () => cancelAnimationFrame(id);
+  }, [from]);
+
+  const activeValues = started ? animate : from;
+  const animStyle = buildAnimStyle(activeValues);
+
+  const duration = transition?.duration ?? 0;
+  const delay = transition?.delay ?? 0;
+  const transitionStyle = {
+    transitionProperty: "opacity, transform",
+    transitionDuration: `${duration}ms`,
+    transitionDelay: `${delay}ms`,
+    transitionTimingFunction: "cubic-bezier(0.22, 1, 0.36, 1)",
+  } as Record<string, string | number>;
+
+  return (
+    <View
+      ref={ref}
+      style={[style, animStyle as object, transitionStyle as object]}
+      {...rest}
+    />
+  );
 });

--- a/components/design-system/__tests__/MotionView.web.test.tsx
+++ b/components/design-system/__tests__/MotionView.web.test.tsx
@@ -4,8 +4,8 @@
  * Web 実装を直接テストするために絶対パスで .web.tsx を import する。
  */
 import React from "react";
-import { create, act } from "react-test-renderer";
-// eslint-disable-next-line import/no-unresolved
+import { render } from "@testing-library/react-native";
+
 import { MotionView } from "../MotionView.web";
 
 function flattenStyle(style: unknown): Record<string, unknown> {
@@ -19,82 +19,49 @@ function flattenStyle(style: unknown): Record<string, unknown> {
   return style as Record<string, unknown>;
 }
 
+function getRootStyle(testIDElement: ReturnType<typeof render>): Record<string, unknown> {
+  const root = testIDElement.root;
+  // root は最上位ホストコンポーネント。MotionView 自身が単一の View を返すため
+  // root.findByType 不要で root.props.style を直接読む。
+  return flattenStyle(root.props.style as unknown);
+}
+
 describe("MotionView (web)", () => {
   it("animate の opacity を style.opacity に反映する", () => {
-    let tree: ReturnType<typeof create>;
-    act(() => {
-      tree = create(<MotionView animate={{ opacity: 0.5 }} />);
-    });
-    const root = tree!.toJSON();
-    const style = flattenStyle(
-      Array.isArray(root) ? undefined : (root?.props as { style?: unknown })?.style
-    );
+    const result = render(<MotionView animate={{ opacity: 0.5 }} />);
+    const style = getRootStyle(result);
     expect(style.opacity).toBe(0.5);
-    act(() => {
-      tree!.unmount();
-    });
+    result.unmount();
   });
 
   it("animate の translateX / scale を transform 文字列に合成する", () => {
-    let tree: ReturnType<typeof create>;
-    act(() => {
-      tree = create(<MotionView animate={{ translateX: 10, scale: 1.2 }} />);
-    });
-    const root = tree!.toJSON();
-    const style = flattenStyle(
-      Array.isArray(root) ? undefined : (root?.props as { style?: unknown })?.style
-    );
-    act(() => {
-      tree!.unmount();
-    });
+    const result = render(<MotionView animate={{ translateX: 10, scale: 1.2 }} />);
+    const style = getRootStyle(result);
     expect(style.transform).toBe("translateX(10px) scale(1.2)");
+    result.unmount();
   });
 
   it("transition.duration を style.transitionDuration に反映する", () => {
-    let tree: ReturnType<typeof create>;
-    act(() => {
-      tree = create(<MotionView animate={{ opacity: 1 }} transition={{ duration: 300 }} />);
-    });
-    const root = tree!.toJSON();
-    const style = flattenStyle(
-      Array.isArray(root) ? undefined : (root?.props as { style?: unknown })?.style
-    );
-    act(() => {
-      tree!.unmount();
-    });
+    const result = render(<MotionView animate={{ opacity: 1 }} transition={{ duration: 300 }} />);
+    const style = getRootStyle(result);
     expect(style.transitionDuration).toBe("300ms");
+    result.unmount();
   });
 
   it("配列（キーフレーム）が渡された場合は末尾の値を使用する", () => {
-    let tree: ReturnType<typeof create>;
-    act(() => {
-      tree = create(<MotionView animate={{ translateX: [-10, 10, 0] }} />);
-    });
-    const root = tree!.toJSON();
-    const style = flattenStyle(
-      Array.isArray(root) ? undefined : (root?.props as { style?: unknown })?.style
-    );
-    act(() => {
-      tree!.unmount();
-    });
+    const result = render(<MotionView animate={{ translateX: [-10, 10, 0] }} />);
+    const style = getRootStyle(result);
     expect(style.transform).toBe("translateX(0px)");
+    result.unmount();
   });
 
   it("from が指定されていれば初回レンダーは from 値を使う", () => {
-    let tree: ReturnType<typeof create>;
-    act(() => {
-      tree = create(
-        <MotionView from={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 100 }} />
-      );
-    });
-    const root = tree!.toJSON();
-    const style = flattenStyle(
-      Array.isArray(root) ? undefined : (root?.props as { style?: unknown })?.style
+    const result = render(
+      <MotionView from={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 100 }} />
     );
-    act(() => {
-      tree!.unmount();
-    });
+    const style = getRootStyle(result);
     // useEffect の requestAnimationFrame 発火前なので from が反映される
     expect(style.opacity).toBe(0);
+    result.unmount();
   });
 });

--- a/components/design-system/__tests__/MotionView.web.test.tsx
+++ b/components/design-system/__tests__/MotionView.web.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * MotionView.web の style マッピングの単体テスト。
+ * jest-expo 配下のため、通常の import では .native.tsx が解決される。
+ * Web 実装を直接テストするために絶対パスで .web.tsx を import する。
+ */
+import React from "react";
+import { create, act } from "react-test-renderer";
+// eslint-disable-next-line import/no-unresolved
+import { MotionView } from "../MotionView.web";
+
+function flattenStyle(style: unknown): Record<string, unknown> {
+  if (!style) return {};
+  if (Array.isArray(style)) {
+    return style.reduce<Record<string, unknown>>(
+      (acc, item) => ({ ...acc, ...flattenStyle(item) }),
+      {}
+    );
+  }
+  return style as Record<string, unknown>;
+}
+
+describe("MotionView (web)", () => {
+  it("animate の opacity を style.opacity に反映する", () => {
+    let tree: ReturnType<typeof create>;
+    act(() => {
+      tree = create(<MotionView animate={{ opacity: 0.5 }} />);
+    });
+    const root = tree!.toJSON();
+    const style = flattenStyle(
+      Array.isArray(root) ? undefined : (root?.props as { style?: unknown })?.style
+    );
+    expect(style.opacity).toBe(0.5);
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it("animate の translateX / scale を transform 文字列に合成する", () => {
+    let tree: ReturnType<typeof create>;
+    act(() => {
+      tree = create(<MotionView animate={{ translateX: 10, scale: 1.2 }} />);
+    });
+    const root = tree!.toJSON();
+    const style = flattenStyle(
+      Array.isArray(root) ? undefined : (root?.props as { style?: unknown })?.style
+    );
+    act(() => {
+      tree!.unmount();
+    });
+    expect(style.transform).toBe("translateX(10px) scale(1.2)");
+  });
+
+  it("transition.duration を style.transitionDuration に反映する", () => {
+    let tree: ReturnType<typeof create>;
+    act(() => {
+      tree = create(<MotionView animate={{ opacity: 1 }} transition={{ duration: 300 }} />);
+    });
+    const root = tree!.toJSON();
+    const style = flattenStyle(
+      Array.isArray(root) ? undefined : (root?.props as { style?: unknown })?.style
+    );
+    act(() => {
+      tree!.unmount();
+    });
+    expect(style.transitionDuration).toBe("300ms");
+  });
+
+  it("配列（キーフレーム）が渡された場合は末尾の値を使用する", () => {
+    let tree: ReturnType<typeof create>;
+    act(() => {
+      tree = create(<MotionView animate={{ translateX: [-10, 10, 0] }} />);
+    });
+    const root = tree!.toJSON();
+    const style = flattenStyle(
+      Array.isArray(root) ? undefined : (root?.props as { style?: unknown })?.style
+    );
+    act(() => {
+      tree!.unmount();
+    });
+    expect(style.transform).toBe("translateX(0px)");
+  });
+
+  it("from が指定されていれば初回レンダーは from 値を使う", () => {
+    let tree: ReturnType<typeof create>;
+    act(() => {
+      tree = create(
+        <MotionView from={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 100 }} />
+      );
+    });
+    const root = tree!.toJSON();
+    const style = flattenStyle(
+      Array.isArray(root) ? undefined : (root?.props as { style?: unknown })?.style
+    );
+    act(() => {
+      tree!.unmount();
+    });
+    // useEffect の requestAnimationFrame 発火前なので from が反映される
+    expect(style.opacity).toBe(0);
+  });
+});


### PR DESCRIPTION
## 目的

Web 版の `MotionView` は `animate` / `from` / `transition` を無視して素の `View` を返しており、Moti ベースのアニメーション（fade/slide/scale など）が Web でまったく効かない状態だった。最小の CSS transition サブセットを実装して Web でも視覚体験を提供する。

## 変更点

- `components/design-system/MotionView.web.tsx`: CSS transition + transform ベースの実装に差し替え
  - `animate` / `from`: `opacity` / `translateX` / `translateY` / `scale` / `rotateZ`
    - 数値・文字列・配列（末尾値のみ採用）を受け付け
  - `transition`: `duration` / `delay` を反映。easing は `cubic-bezier(0.22, 1, 0.36, 1)` 固定
  - `from → animate` は `useEffect` + `requestAnimationFrame` で 1 フレーム遅延
  - `exit` / `state` / `loop` / `repeatReverse` / キーフレーム中間値は未対応（TODO コメントで明記、将来 framer-motion 等で拡張）
- `components/design-system/MotionView.native.tsx`: 不変（Moti そのまま）
- `components/design-system/MotionView.d.ts`: 既存シグネチャを維持

## テスト結果

\`\`\`
$ pnpm exec jest components/design-system/__tests__/MotionView.web.test.tsx
Tests:       5 passed, 5 total

$ pnpm exec jest   # 全テスト
Tests:       215 passed, 215 total

$ pnpm lint         # クリーン
$ pnpm exec tsc --noEmit  # クリーン
\`\`\`

## 影響範囲

- Web のみ（`react-native-web` 環境）
- ネイティブ挙動は不変
- 既存の MotionView 利用箇所（ShakingPattern / RevealStickStage / RitualProgressOverlay / PaperResultCard）で props の型は変わらず

## レビュー観点

- `style` 配列への CSS プロパティ注入が react-native-web のランタイムで期待通り `<div style="...">` に変換されるか、実ブラウザで要確認
- 複雑なループアニメーション（ShakingPattern の 🫨 ゆらぎ）は最終フレームに固定される。ユーザー価値としては妥当だが、気になる場合は今後 keyframe 対応を検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)