### PR TITLE
refactor: 色リテラルを semantic token へ統一

### DIFF
--- a/app/history.tsx
+++ b/app/history.tsx
@@ -9,6 +9,7 @@ import { HistoryScreenTemplate } from "../components/templates/HistoryScreenTemp
 import { PageHeader } from "../components/design-system/PageHeader";
 import { Button } from "../components/design-system/Button";
 import { HistoryListPattern } from "../components/patterns/HistoryListPattern";
+import { getStringToken } from "../design-system";
 
 export default function HistoryScreen() {
   const { t } = useTranslation();
@@ -79,7 +80,9 @@ export default function HistoryScreen() {
       content={
         isLoading ? (
           <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
-            <Text style={{ color: "rgba(255,255,255,0.72)", fontSize: 16 }}>読み込み中...</Text>
+            <Text style={{ color: getStringToken("semantic.text.muted"), fontSize: 16 }}>
+              読み込み中...
+            </Text>
           </View>
         ) : (
           <HistoryListPattern history={history} />

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -19,6 +19,7 @@ import { RevealStickStage } from "../components/design-system/RevealStickStage";
 import { Button } from "../components/design-system/Button";
 import { MuteToggle } from "../components/design-system/MuteToggle";
 import { PageHeader } from "../components/design-system/PageHeader";
+import { getStringToken } from "../design-system";
 
 const SHAKE_THRESHOLD = 1.8;
 
@@ -85,7 +86,13 @@ export default function OmikujiApp() {
       footer={
         appState === "IDLE" && !isCompactLayout ? (
           <View style={{ alignItems: "center", gap: 4 }}>
-            <Text style={{ color: "rgba(255,255,255,0.35)", fontSize: 11, textAlign: "center" }}>
+            <Text
+              style={{
+                color: getStringToken("semantic.text.experience.hint"),
+                fontSize: 11,
+                textAlign: "center",
+              }}
+            >
               {t("disclaimer.inline")}
             </Text>
             <VersionDisplay />

--- a/components/design-system/HistoryEmptyState.tsx
+++ b/components/design-system/HistoryEmptyState.tsx
@@ -17,9 +17,9 @@ export function HistoryEmptyState() {
           borderRadius: 80,
           alignItems: "center",
           justifyContent: "center",
-          backgroundColor: "rgba(255, 255, 255, 0.08)",
+          backgroundColor: getStringToken("semantic.surface.experience.historyPlaceholder"),
           borderWidth: 1,
-          borderColor: "rgba(255, 255, 255, 0.18)",
+          borderColor: getStringToken("semantic.border.soft"),
           marginBottom: 20,
         }}
       >
@@ -32,7 +32,7 @@ export function HistoryEmptyState() {
       </View>
       <Text
         style={{
-          color: "rgba(255, 255, 255, 0.74)",
+          color: getStringToken("semantic.text.muted"),
           fontSize: 18,
           fontFamily: getStringToken("primitive.typography.family.ritualBody"),
           textAlign: "center",

--- a/components/design-system/PaperResultCard.tsx
+++ b/components/design-system/PaperResultCard.tsx
@@ -173,7 +173,7 @@ export function PaperResultCard({
                   marginTop: isCompactHeight ? 14 : 20,
                   paddingTop: isCompactHeight ? 14 : 18,
                   borderTopWidth: 1,
-                  borderTopColor: "rgba(180, 83, 9, 0.18)",
+                  borderTopColor: getStringToken("semantic.border.paperDivider"),
                   gap: isCompactHeight ? 10 : 14,
                 }}
               >
@@ -208,7 +208,7 @@ export function PaperResultCard({
                 padding: 16,
                 paddingVertical: isCompactHeight ? 12 : 16,
                 borderTopWidth: 1,
-                borderTopColor: "rgba(180, 83, 9, 0.18)",
+                borderTopColor: getStringToken("semantic.border.paperDivider"),
                 gap: isCompactHeight ? 8 : 10,
               }}
             >

--- a/components/design-system/RevealStickStage.tsx
+++ b/components/design-system/RevealStickStage.tsx
@@ -8,11 +8,12 @@ interface RevealStickStageProps {
 }
 
 export function RevealStickStage({ reducedMotion = false }: RevealStickStageProps) {
+  const shadowColor = getStringToken("primitive.color.black");
   const containerShadowStyle =
     Platform.OS === "web"
       ? { boxShadow: "0px 12px 24px rgba(0, 0, 0, 0.25)" }
       : {
-          shadowColor: "#000000",
+          shadowColor,
           shadowOffset: { width: 0, height: 12 },
           shadowOpacity: 0.25,
           shadowRadius: 24,
@@ -23,12 +24,14 @@ export function RevealStickStage({ reducedMotion = false }: RevealStickStageProp
     Platform.OS === "web"
       ? { boxShadow: "0px 8px 16px rgba(0, 0, 0, 0.18)" }
       : {
-          shadowColor: "#000000",
+          shadowColor,
           shadowOffset: { width: 0, height: 8 },
           shadowOpacity: 0.18,
           shadowRadius: 16,
           elevation: 6,
         };
+
+  const revealHighlightColor = getStringToken("semantic.surface.experience.revealHighlight");
 
   return (
     <View
@@ -58,10 +61,10 @@ export function RevealStickStage({ reducedMotion = false }: RevealStickStageProp
           style={{
             width: 176,
             height: 208,
-            backgroundColor: "#7F1D1D",
+            backgroundColor: getStringToken("semantic.surface.experience.revealContainer"),
             borderRadius: 28,
             borderWidth: 4,
-            borderColor: "#D4A017",
+            borderColor: getStringToken("semantic.border.experience.revealContainer"),
             alignItems: "center",
             justifyContent: "center",
             ...containerShadowStyle,
@@ -72,7 +75,7 @@ export function RevealStickStage({ reducedMotion = false }: RevealStickStageProp
               width: 92,
               height: 8,
               borderRadius: 999,
-              backgroundColor: "rgba(251, 191, 36, 0.24)",
+              backgroundColor: revealHighlightColor,
               marginBottom: 10,
             }}
           />
@@ -81,7 +84,7 @@ export function RevealStickStage({ reducedMotion = false }: RevealStickStageProp
               width: 72,
               height: 8,
               borderRadius: 999,
-              backgroundColor: "rgba(251, 191, 36, 0.24)",
+              backgroundColor: revealHighlightColor,
             }}
           />
         </MotionView>
@@ -98,14 +101,14 @@ export function RevealStickStage({ reducedMotion = false }: RevealStickStageProp
             position: "absolute",
             width: 68,
             height: 196,
-            backgroundColor: "#FEF3C7",
+            backgroundColor: getStringToken("semantic.surface.experience.revealStick"),
             bottom: 44,
             borderTopLeftRadius: 18,
             borderTopRightRadius: 18,
             borderLeftWidth: 2,
             borderRightWidth: 2,
             borderTopWidth: 2,
-            borderColor: "#FDE68A",
+            borderColor: getStringToken("semantic.border.experience.revealStick"),
             alignItems: "center",
             justifyContent: "flex-start",
             paddingTop: 18,
@@ -114,7 +117,7 @@ export function RevealStickStage({ reducedMotion = false }: RevealStickStageProp
         >
           <Text
             style={{
-              color: "#B91C1C",
+              color: getStringToken("semantic.text.experience.revealStick"),
               fontSize: 15,
               lineHeight: 18,
               textAlign: "center",
@@ -139,7 +142,7 @@ export function RevealStickStage({ reducedMotion = false }: RevealStickStageProp
             width: 172,
             height: 172,
             borderRadius: 86,
-            backgroundColor: "rgba(251, 191, 36, 0.22)",
+            backgroundColor: getStringToken("semantic.surface.experience.revealHalo"),
           }}
         />
       </View>

--- a/components/design-system/TiedCompleteView.tsx
+++ b/components/design-system/TiedCompleteView.tsx
@@ -39,18 +39,18 @@ export function TiedCompleteView({ onClose }: TiedCompleteViewProps) {
         <Text style={{ fontSize: 40 }}>🌿</Text>
         <View
           style={{
-            backgroundColor: "rgba(255,255,255,0.92)",
+            backgroundColor: getStringToken("semantic.surface.experience.tiedPaper"),
             paddingHorizontal: 12,
             paddingVertical: 16,
             marginHorizontal: 4,
             borderRadius: 8,
             borderWidth: 1,
-            borderColor: "#FDE68A",
+            borderColor: getStringToken("semantic.border.experience.tiedPaper"),
           }}
         >
           <Text
             style={{
-              color: "#B91C1C",
+              color: getStringToken("semantic.text.experience.tiedHeading"),
               fontSize: 13,
               textAlign: "center",
               fontFamily: ritualFontFamily,
@@ -74,7 +74,7 @@ export function TiedCompleteView({ onClose }: TiedCompleteViewProps) {
       </Text>
       <Text
         style={{
-          color: "rgba(255,255,255,0.72)",
+          color: getStringToken("semantic.text.muted"),
           textAlign: "center",
           marginTop: 10,
           lineHeight: 24,

--- a/docs/design-system/tokens/primitive.json
+++ b/docs/design-system/tokens/primitive.json
@@ -8,13 +8,17 @@
     "black": { "value": "#000000" },
     "white": { "value": "#FFFFFF" },
     "red": {
+      "800": { "value": "#7F1D1D" },
       "700": { "value": "#B91C1C" },
       "600": { "value": "#DC2626" }
     },
     "amber": {
+      "100": { "value": "#FEF3C7" },
+      "200": { "value": "#FDE68A" },
       "300": { "value": "#FCD34D" },
       "400": { "value": "#FBBF24" },
       "500": { "value": "#F59E0B" },
+      "600": { "value": "#D4A017" },
       "700": { "value": "#B45309" }
     },
     "slate": {

--- a/docs/design-system/tokens/semantic.json
+++ b/docs/design-system/tokens/semantic.json
@@ -10,7 +10,13 @@
       "accentPressed": { "value": "{primitive.color.red.700}" },
       "warm": { "value": "{primitive.color.amber.500}" },
       "warmPressed": { "value": "{primitive.color.amber.700}" },
-      "quiet": { "value": "rgba(15, 23, 42, 0.88)" }
+      "quiet": { "value": "rgba(15, 23, 42, 0.88)" },
+      "revealContainer": { "value": "{primitive.color.red.800}" },
+      "revealStick": { "value": "{primitive.color.amber.100}" },
+      "revealHighlight": { "value": "rgba(251, 191, 36, 0.24)" },
+      "revealHalo": { "value": "rgba(251, 191, 36, 0.22)" },
+      "tiedPaper": { "value": "rgba(255, 255, 255, 0.92)" },
+      "historyPlaceholder": { "value": "rgba(255, 255, 255, 0.08)" }
     },
     "document": {
       "canvas": { "value": "{primitive.color.white}" },
@@ -25,13 +31,24 @@
     "accent": { "value": "{primitive.color.amber.300}" },
     "document": { "value": "{primitive.color.gray.900}" },
     "documentMuted": { "value": "{primitive.color.gray.600}" },
-    "danger": { "value": "{primitive.color.red.600}" }
+    "danger": { "value": "{primitive.color.red.600}" },
+    "experience": {
+      "revealStick": { "value": "{primitive.color.red.700}" },
+      "tiedHeading": { "value": "{primitive.color.red.700}" },
+      "hint": { "value": "rgba(255, 255, 255, 0.35)" }
+    }
   },
   "border": {
     "soft": { "value": "rgba(255, 255, 255, 0.18)" },
     "glass": { "value": "rgba(255, 255, 255, 0.24)" },
     "paper": { "value": "rgba(180, 83, 9, 0.22)" },
-    "focus": { "value": "{primitive.color.amber.400}" }
+    "paperDivider": { "value": "rgba(180, 83, 9, 0.18)" },
+    "focus": { "value": "{primitive.color.amber.400}" },
+    "experience": {
+      "revealContainer": { "value": "{primitive.color.amber.600}" },
+      "revealStick": { "value": "{primitive.color.amber.200}" },
+      "tiedPaper": { "value": "{primitive.color.amber.200}" }
+    }
   },
   "feedback": {
     "success": { "value": "{primitive.color.amber.500}" },


### PR DESCRIPTION
## 目的

app / components に散在していた raw `rgba(...)` / `#HEX` リテラルを design-system の semantic token に統一。将来のテーマ切替・WCAG コントラスト管理・ダークモード対応の起点を整える。

## 追加した primitives

| 新規 | 値 |
|------|-----|
| `color.red.800` | `#7F1D1D` |
| `color.amber.100` | `#FEF3C7` |
| `color.amber.200` | `#FDE68A` |
| `color.amber.600` | `#D4A017` |

## 追加した semantic tokens

- `surface.experience.{revealContainer, revealStick, revealHighlight, revealHalo, tiedPaper, historyPlaceholder}`
- `text.experience.{revealStick, tiedHeading, hint}`
- `border.experience.{revealContainer, revealStick, tiedPaper}`
- `border.paperDivider` — 紙の区切り線用（既存 `border.paper` より薄い不透明度）

## 対象ファイル

- `components/design-system/RevealStickStage.tsx`
- `components/design-system/TiedCompleteView.tsx`
- `components/design-system/HistoryEmptyState.tsx`
- `components/design-system/PaperResultCard.tsx`
- `app/index.tsx` / `app/history.tsx`
- `docs/design-system/tokens/primitive.json`
- `docs/design-system/tokens/semantic.json`

## スコープ外（今回触らない）

- `components/design-system/SurfaceCard.tsx` の `boxShadow` 文字列: shadow トークンから format 変換された生成文字列のため、raw 色決定ではない
- `RevealStickStage.tsx` の Web 向け `boxShadow: \"...rgba(0,0,0,0.XX)...\"`: 同上

## テスト結果

\`\`\`
$ pnpm exec jest
Tests:       210 passed, 210 total

$ pnpm exec tsc --noEmit  # クリーン
$ pnpm lint               # クリーン（prettier 自動整形反映済）
\`\`\`

## 見た目の微差分（意図的）

| 箇所 | 旧 | 新 | 差 |
|------|-----|-----|-----|
| HistoryEmptyState 文字色 | `rgba(255,255,255,0.74)` | `text.muted` (`0.72`) | 0.02 不透明度 |
| app/history.tsx 読み込み文字色 | `rgba(255,255,255,0.72)` | `text.muted` (`0.72`) | 一致 |

他は 1:1 の置換。視認性は維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)