### PR TITLE
feat(a11y): 主要コンポーネントにアクセシビリティ属性を追加

### DIFF
--- a/app/history.tsx
+++ b/app/history.tsx
@@ -9,6 +9,7 @@ import { HistoryScreenTemplate } from "../components/templates/HistoryScreenTemp
 import { PageHeader } from "../components/design-system/PageHeader";
 import { Button } from "../components/design-system/Button";
 import { HistoryListPattern } from "../components/patterns/HistoryListPattern";
+import { getStringToken } from "../design-system";
 
 export default function HistoryScreen() {
   const { t } = useTranslation();
@@ -79,7 +80,9 @@ export default function HistoryScreen() {
       content={
         isLoading ? (
           <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
-            <Text style={{ color: "rgba(255,255,255,0.72)", fontSize: 16 }}>読み込み中...</Text>
+            <Text style={{ color: getStringToken("semantic.text.muted"), fontSize: 16 }}>
+              読み込み中...
+            </Text>
           </View>
         ) : (
           <HistoryListPattern history={history} />

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -19,6 +19,7 @@ import { RevealStickStage } from "../components/design-system/RevealStickStage";
 import { Button } from "../components/design-system/Button";
 import { MuteToggle } from "../components/design-system/MuteToggle";
 import { PageHeader } from "../components/design-system/PageHeader";
+import { getStringToken } from "../design-system";
 
 const SHAKE_THRESHOLD = 1.8;
 
@@ -85,7 +86,13 @@ export default function OmikujiApp() {
       footer={
         appState === "IDLE" && !isCompactLayout ? (
           <View style={{ alignItems: "center", gap: 4 }}>
-            <Text style={{ color: "rgba(255,255,255,0.35)", fontSize: 11, textAlign: "center" }}>
+            <Text
+              style={{
+                color: getStringToken("semantic.text.experience.hint"),
+                fontSize: 11,
+                textAlign: "center",
+              }}
+            >
               {t("disclaimer.inline")}
             </Text>
             <VersionDisplay />

--- a/components/design-system/DocumentSection.tsx
+++ b/components/design-system/DocumentSection.tsx
@@ -32,6 +32,7 @@ export function DocumentSection({ title, children, subtle = false }: DocumentSec
           fontWeight: "700",
           marginBottom: 10,
         }}
+        accessibilityRole="header"
       >
         {title}
       </Text>

--- a/components/design-system/HistoryEmptyState.tsx
+++ b/components/design-system/HistoryEmptyState.tsx
@@ -38,6 +38,8 @@ export function HistoryEmptyState() {
           textAlign: "center",
           lineHeight: 28,
         }}
+        accessibilityRole="text"
+        accessibilityLabel={t("history.empty")}
       >
         {t("history.empty")}
       </Text>

--- a/components/design-system/HistoryEmptyState.tsx
+++ b/components/design-system/HistoryEmptyState.tsx
@@ -17,9 +17,9 @@ export function HistoryEmptyState() {
           borderRadius: 80,
           alignItems: "center",
           justifyContent: "center",
-          backgroundColor: "rgba(255, 255, 255, 0.08)",
+          backgroundColor: getStringToken("semantic.surface.experience.historyPlaceholder"),
           borderWidth: 1,
-          borderColor: "rgba(255, 255, 255, 0.18)",
+          borderColor: getStringToken("semantic.border.soft"),
           marginBottom: 20,
         }}
       >
@@ -32,7 +32,7 @@ export function HistoryEmptyState() {
       </View>
       <Text
         style={{
-          color: "rgba(255, 255, 255, 0.74)",
+          color: getStringToken("semantic.text.muted"),
           fontSize: 18,
           fontFamily: getStringToken("primitive.typography.family.ritualBody"),
           textAlign: "center",

--- a/components/design-system/HistoryItemCard.tsx
+++ b/components/design-system/HistoryItemCard.tsx
@@ -35,8 +35,17 @@ export function HistoryItemCard({ item, fortuneTitle, fortuneMessage }: HistoryI
     ? getFortuneLevelColor(item.level)
     : getStringToken("semantic.text.primary");
 
+  const formattedDate = formatDate(item.createdAt);
+  // スクリーンリーダーでは「大吉。2026年4月11日 09:30。最高の運気です。」のように読み上げる
+  const combinedA11yLabel = `${fortuneTitle}。${formattedDate}。${fortuneMessage}`;
+
   return (
-    <SurfaceCard variant="glassCard">
+    <SurfaceCard
+      variant="glassCard"
+      accessible
+      accessibilityLabel={combinedA11yLabel}
+      accessibilityRole="summary"
+    >
       <View style={{ flexDirection: "row", justifyContent: "space-between", gap: 16 }}>
         <Text
           style={{
@@ -48,7 +57,7 @@ export function HistoryItemCard({ item, fortuneTitle, fortuneMessage }: HistoryI
           {fortuneTitle}
         </Text>
         <Text style={{ color: tokens.metaColor, fontSize: 12, flexShrink: 1, textAlign: "right" }}>
-          {formatDate(item.createdAt)}
+          {formattedDate}
         </Text>
       </View>
       <Text

--- a/components/design-system/PageHeader.tsx
+++ b/components/design-system/PageHeader.tsx
@@ -86,7 +86,9 @@ export function PageHeader({
             <View style={{ flexDirection: "row", alignItems: "center", gap: 12 }}>
               {leadingAction}
               <View style={{ flexShrink: 1 }}>
-                <Text style={titleStyle}>{title}</Text>
+                <Text style={titleStyle} accessibilityRole="header">
+                  {title}
+                </Text>
                 {subtitle ? (
                   <Text style={{ color: subtitleColor, marginTop: 6, fontSize: 14 }}>
                     {subtitle}

--- a/components/design-system/PaperResultCard.tsx
+++ b/components/design-system/PaperResultCard.tsx
@@ -173,7 +173,7 @@ export function PaperResultCard({
                   marginTop: isCompactHeight ? 14 : 20,
                   paddingTop: isCompactHeight ? 14 : 18,
                   borderTopWidth: 1,
-                  borderTopColor: "rgba(180, 83, 9, 0.18)",
+                  borderTopColor: getStringToken("semantic.border.paperDivider"),
                   gap: isCompactHeight ? 10 : 14,
                 }}
               >
@@ -208,7 +208,7 @@ export function PaperResultCard({
                 padding: 16,
                 paddingVertical: isCompactHeight ? 12 : 16,
                 borderTopWidth: 1,
-                borderTopColor: "rgba(180, 83, 9, 0.18)",
+                borderTopColor: getStringToken("semantic.border.paperDivider"),
                 gap: isCompactHeight ? 8 : 10,
               }}
             >

--- a/components/design-system/PaperResultCard.tsx
+++ b/components/design-system/PaperResultCard.tsx
@@ -146,6 +146,8 @@ export function PaperResultCard({
               showsVerticalScrollIndicator
             >
               <Text
+                accessibilityRole="header"
+                accessibilityLabel={`運勢は${fortuneTitle}`}
                 style={{
                   fontSize: isCompactHeight ? 42 : 54,
                   textAlign: "center",
@@ -156,6 +158,7 @@ export function PaperResultCard({
                 {fortuneTitle}
               </Text>
               <Text
+                accessibilityRole="text"
                 style={{
                   marginTop: isCompactHeight ? 8 : 10,
                   color: resultTokens.bodyColor,
@@ -180,6 +183,8 @@ export function PaperResultCard({
                 {detailEntries.map((entry) => (
                   <View
                     key={entry.key}
+                    accessible
+                    accessibilityLabel={`${entry.label}。${entry.value}`}
                     style={{
                       flexDirection: "row",
                       gap: 12,

--- a/components/design-system/RevealStickStage.tsx
+++ b/components/design-system/RevealStickStage.tsx
@@ -8,11 +8,12 @@ interface RevealStickStageProps {
 }
 
 export function RevealStickStage({ reducedMotion = false }: RevealStickStageProps) {
+  const shadowColor = getStringToken("primitive.color.black");
   const containerShadowStyle =
     Platform.OS === "web"
       ? { boxShadow: "0px 12px 24px rgba(0, 0, 0, 0.25)" }
       : {
-          shadowColor: "#000000",
+          shadowColor,
           shadowOffset: { width: 0, height: 12 },
           shadowOpacity: 0.25,
           shadowRadius: 24,
@@ -23,12 +24,14 @@ export function RevealStickStage({ reducedMotion = false }: RevealStickStageProp
     Platform.OS === "web"
       ? { boxShadow: "0px 8px 16px rgba(0, 0, 0, 0.18)" }
       : {
-          shadowColor: "#000000",
+          shadowColor,
           shadowOffset: { width: 0, height: 8 },
           shadowOpacity: 0.18,
           shadowRadius: 16,
           elevation: 6,
         };
+
+  const revealHighlightColor = getStringToken("semantic.surface.experience.revealHighlight");
 
   return (
     <View
@@ -58,10 +61,10 @@ export function RevealStickStage({ reducedMotion = false }: RevealStickStageProp
           style={{
             width: 176,
             height: 208,
-            backgroundColor: "#7F1D1D",
+            backgroundColor: getStringToken("semantic.surface.experience.revealContainer"),
             borderRadius: 28,
             borderWidth: 4,
-            borderColor: "#D4A017",
+            borderColor: getStringToken("semantic.border.experience.revealContainer"),
             alignItems: "center",
             justifyContent: "center",
             ...containerShadowStyle,
@@ -72,7 +75,7 @@ export function RevealStickStage({ reducedMotion = false }: RevealStickStageProp
               width: 92,
               height: 8,
               borderRadius: 999,
-              backgroundColor: "rgba(251, 191, 36, 0.24)",
+              backgroundColor: revealHighlightColor,
               marginBottom: 10,
             }}
           />
@@ -81,7 +84,7 @@ export function RevealStickStage({ reducedMotion = false }: RevealStickStageProp
               width: 72,
               height: 8,
               borderRadius: 999,
-              backgroundColor: "rgba(251, 191, 36, 0.24)",
+              backgroundColor: revealHighlightColor,
             }}
           />
         </MotionView>
@@ -98,14 +101,14 @@ export function RevealStickStage({ reducedMotion = false }: RevealStickStageProp
             position: "absolute",
             width: 68,
             height: 196,
-            backgroundColor: "#FEF3C7",
+            backgroundColor: getStringToken("semantic.surface.experience.revealStick"),
             bottom: 44,
             borderTopLeftRadius: 18,
             borderTopRightRadius: 18,
             borderLeftWidth: 2,
             borderRightWidth: 2,
             borderTopWidth: 2,
-            borderColor: "#FDE68A",
+            borderColor: getStringToken("semantic.border.experience.revealStick"),
             alignItems: "center",
             justifyContent: "flex-start",
             paddingTop: 18,
@@ -114,7 +117,7 @@ export function RevealStickStage({ reducedMotion = false }: RevealStickStageProp
         >
           <Text
             style={{
-              color: "#B91C1C",
+              color: getStringToken("semantic.text.experience.revealStick"),
               fontSize: 15,
               lineHeight: 18,
               textAlign: "center",
@@ -139,7 +142,7 @@ export function RevealStickStage({ reducedMotion = false }: RevealStickStageProp
             width: 172,
             height: 172,
             borderRadius: 86,
-            backgroundColor: "rgba(251, 191, 36, 0.22)",
+            backgroundColor: getStringToken("semantic.surface.experience.revealHalo"),
           }}
         />
       </View>

--- a/components/design-system/TiedCompleteView.tsx
+++ b/components/design-system/TiedCompleteView.tsx
@@ -62,6 +62,7 @@ export function TiedCompleteView({ onClose }: TiedCompleteViewProps) {
         <Text style={{ fontSize: 40 }}>🌿</Text>
       </View>
       <Text
+        accessibilityRole="header"
         style={{
           color: "white",
           fontSize: 22,

--- a/components/design-system/TiedCompleteView.tsx
+++ b/components/design-system/TiedCompleteView.tsx
@@ -39,18 +39,18 @@ export function TiedCompleteView({ onClose }: TiedCompleteViewProps) {
         <Text style={{ fontSize: 40 }}>🌿</Text>
         <View
           style={{
-            backgroundColor: "rgba(255,255,255,0.92)",
+            backgroundColor: getStringToken("semantic.surface.experience.tiedPaper"),
             paddingHorizontal: 12,
             paddingVertical: 16,
             marginHorizontal: 4,
             borderRadius: 8,
             borderWidth: 1,
-            borderColor: "#FDE68A",
+            borderColor: getStringToken("semantic.border.experience.tiedPaper"),
           }}
         >
           <Text
             style={{
-              color: "#B91C1C",
+              color: getStringToken("semantic.text.experience.tiedHeading"),
               fontSize: 13,
               textAlign: "center",
               fontFamily: ritualFontFamily,
@@ -74,7 +74,7 @@ export function TiedCompleteView({ onClose }: TiedCompleteViewProps) {
       </Text>
       <Text
         style={{
-          color: "rgba(255,255,255,0.72)",
+          color: getStringToken("semantic.text.muted"),
           textAlign: "center",
           marginTop: 10,
           lineHeight: 24,

--- a/docs/design-system/tokens/primitive.json
+++ b/docs/design-system/tokens/primitive.json
@@ -8,13 +8,17 @@
     "black": { "value": "#000000" },
     "white": { "value": "#FFFFFF" },
     "red": {
+      "800": { "value": "#7F1D1D" },
       "700": { "value": "#B91C1C" },
       "600": { "value": "#DC2626" }
     },
     "amber": {
+      "100": { "value": "#FEF3C7" },
+      "200": { "value": "#FDE68A" },
       "300": { "value": "#FCD34D" },
       "400": { "value": "#FBBF24" },
       "500": { "value": "#F59E0B" },
+      "600": { "value": "#D4A017" },
       "700": { "value": "#B45309" }
     },
     "slate": {

--- a/docs/design-system/tokens/semantic.json
+++ b/docs/design-system/tokens/semantic.json
@@ -10,7 +10,13 @@
       "accentPressed": { "value": "{primitive.color.red.700}" },
       "warm": { "value": "{primitive.color.amber.500}" },
       "warmPressed": { "value": "{primitive.color.amber.700}" },
-      "quiet": { "value": "rgba(15, 23, 42, 0.88)" }
+      "quiet": { "value": "rgba(15, 23, 42, 0.88)" },
+      "revealContainer": { "value": "{primitive.color.red.800}" },
+      "revealStick": { "value": "{primitive.color.amber.100}" },
+      "revealHighlight": { "value": "rgba(251, 191, 36, 0.24)" },
+      "revealHalo": { "value": "rgba(251, 191, 36, 0.22)" },
+      "tiedPaper": { "value": "rgba(255, 255, 255, 0.92)" },
+      "historyPlaceholder": { "value": "rgba(255, 255, 255, 0.08)" }
     },
     "document": {
       "canvas": { "value": "{primitive.color.white}" },
@@ -25,13 +31,24 @@
     "accent": { "value": "{primitive.color.amber.300}" },
     "document": { "value": "{primitive.color.gray.900}" },
     "documentMuted": { "value": "{primitive.color.gray.600}" },
-    "danger": { "value": "{primitive.color.red.600}" }
+    "danger": { "value": "{primitive.color.red.600}" },
+    "experience": {
+      "revealStick": { "value": "{primitive.color.red.700}" },
+      "tiedHeading": { "value": "{primitive.color.red.700}" },
+      "hint": { "value": "rgba(255, 255, 255, 0.35)" }
+    }
   },
   "border": {
     "soft": { "value": "rgba(255, 255, 255, 0.18)" },
     "glass": { "value": "rgba(255, 255, 255, 0.24)" },
     "paper": { "value": "rgba(180, 83, 9, 0.22)" },
-    "focus": { "value": "{primitive.color.amber.400}" }
+    "paperDivider": { "value": "rgba(180, 83, 9, 0.18)" },
+    "focus": { "value": "{primitive.color.amber.400}" },
+    "experience": {
+      "revealContainer": { "value": "{primitive.color.amber.600}" },
+      "revealStick": { "value": "{primitive.color.amber.200}" },
+      "tiedPaper": { "value": "{primitive.color.amber.200}" }
+    }
   },
   "feedback": {
     "success": { "value": "{primitive.color.amber.500}" },


### PR DESCRIPTION
## 目的

design-system 配下 13 コンポーネント中、accessibility 対応済は 3 のみ（Button / MuteToggle / RitualProgressOverlay）。結果表示・履歴・ヘッダー等の主要コンポーネントにスクリーンリーダー対応を拡充する。

## ⚠️ 依存関係

このブランチは **agent/color-tokens (#355)** の上に作成されている。
**#355 マージ後にこの PR を develop に rebase** すれば競合なしで取り込める。
それまでは PR 差分として #355 のコミットも一時的に含まれる。

## 変更点

| ファイル | a11y 追加内容 |
|----------|--------------|
| `PageHeader.tsx` | title に `accessibilityRole="header"` |
| `PaperResultCard.tsx` | 運勢タイトル: role=header + label "運勢は{title}"、メッセージ: role=text、detail 行: `accessible` + label "{label}。{value}" |
| `HistoryItemCard.tsx` | カード全体: `accessible` + role=summary + label タイトル・日付・本文連結 |
| `HistoryEmptyState.tsx` | 空状態テキスト: role=text + explicit label |
| `DocumentSection.tsx` | セクションタイトル: role=header |
| `TiedCompleteView.tsx` | 完了見出し: role=header |

すべて **attributes 追加のみ**。見た目・挙動は不変。

## テスト結果

\`\`\`
$ pnpm exec jest
Tests:       210 passed, 210 total

$ pnpm exec tsc --noEmit  # クリーン
$ pnpm lint               # クリーン
\`\`\`

## 手動確認推奨

- iOS VoiceOver で主要 3 画面（Home / Result / History）を読み上げ
- Android TalkBack で同様に確認
- Web の screen reader (VoiceOver Safari / NVDA Chrome) で Result カードが詳細項目まで読み上げられるか

## レビュー観点

- `accessibilityRole="summary"` は RN で有効（iOS VoiceOver に \"summary element\" として伝達）。
- HistoryItemCard の combined label は fortuneTitle→日付→fortuneMessage の順。スクリーンリーダーで自然な順番か。
- PaperResultCard のタイトル label \"運勢は{title}\" は既存視覚の「{title}（大吉 etc.）」を補強するもの。冗長なら除去可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)