### PR TITLE
fix: セルフレビュー指摘 2 件を修正 (MotionView rotate 別名 / Sound リカバリリーク)

### DIFF
--- a/components/design-system/MotionView.web.tsx
+++ b/components/design-system/MotionView.web.tsx
@@ -24,6 +24,8 @@ type AnimDict = {
   translateY?: AnimValue;
   scale?: AnimValue;
   rotateZ?: AnimValue;
+  // Moti は `rotate` と `rotateZ` を同義として受ける。既存コード互換のため両方許容する。
+  rotate?: AnimValue;
 };
 
 type TransitionDict = {
@@ -63,13 +65,14 @@ function buildAnimStyle(values: AnimDict | undefined): Record<string, string | n
   const translateX = pickLastValue(values.translateX);
   const translateY = pickLastValue(values.translateY);
   const scale = pickLastValue(values.scale);
-  const rotateZ = pickLastValue(values.rotateZ);
+  // rotate / rotateZ を同義として扱う（rotateZ を優先）
+  const rotateValue = pickLastValue(values.rotateZ) ?? pickLastValue(values.rotate);
 
   const transforms: string[] = [];
   if (translateX !== undefined) transforms.push(`translateX(${toPxOrValue(translateX)})`);
   if (translateY !== undefined) transforms.push(`translateY(${toPxOrValue(translateY)})`);
   if (scale !== undefined) transforms.push(`scale(${scale})`);
-  if (rotateZ !== undefined) transforms.push(`rotate(${rotateZ})`);
+  if (rotateValue !== undefined) transforms.push(`rotate(${rotateValue})`);
   if (transforms.length > 0) style.transform = transforms.join(" ");
 
   return style;

--- a/components/design-system/__tests__/MotionView.web.test.tsx
+++ b/components/design-system/__tests__/MotionView.web.test.tsx
@@ -64,4 +64,18 @@ describe("MotionView (web)", () => {
     expect(style.opacity).toBe(0);
     result.unmount();
   });
+
+  it("rotate を rotateZ の別名として受け付ける (Moti 互換)", () => {
+    const result = render(<MotionView animate={{ rotate: "180deg" }} />);
+    const style = getRootStyle(result);
+    expect(style.transform).toBe("rotate(180deg)");
+    result.unmount();
+  });
+
+  it("rotateZ が指定されている場合は rotate より優先する", () => {
+    const result = render(<MotionView animate={{ rotateZ: "90deg", rotate: "45deg" }} />);
+    const style = getRootStyle(result);
+    expect(style.transform).toBe("rotate(90deg)");
+    result.unmount();
+  });
 });

--- a/utils/SoundManager.ts
+++ b/utils/SoundManager.ts
@@ -70,6 +70,13 @@ class SoundManager {
         return;
       }
       try {
+        // 古い Sound オブジェクトを明示的にアンロードしてから再ロードする（リソースリーク防止）。
+        // unloadAsync 自体の失敗は致命的でないため握りつぶす。
+        try {
+          await sound.unloadAsync();
+        } catch {
+          /* noop */
+        }
         this.sounds.delete(key);
         const reloaded = await this.loadSound(key, source);
         if (reloaded) {


### PR DESCRIPTION
## 目的

品質向上 PR 群 (#350-#356) 完了後の並行エージェント検証で発見した 2 件の回帰を修正する。

## 修正 1: MotionView.web の rotate / rotateZ 別名対応

**症状**: PR #353 では `rotateZ` のみをサポートしたが、実際の呼び出し元は `rotate` キーを使用していたため Web で回転アニメーションが無視されていた。

**影響**:
- `RevealStickStage.tsx` L56-57: おみくじ棒の 180deg→0deg 回転
- `RitualProgressOverlay.tsx` L82-83: 進捗リングの 360deg ループ回転

いずれも Web では静止していた。ネイティブは Moti がそのまま処理するため影響なし。

**対応**:
- `components/design-system/MotionView.web.tsx`: `AnimDict` に `rotate?` を追加し、`rotateZ` > `rotate` の優先順位で合成（Moti 自体が両方を同義として扱うため）
- `__tests__/MotionView.web.test.tsx`: rotate alias と rotateZ 優先の回帰テスト 2 件追加

## 修正 2: SoundManager リカバリ時のリソースリーク防止

**症状**: PR #350 のフォールバック経路で古い `Sound` オブジェクトを `unloadAsync` せずに Map から delete していた。長時間使用・大量おみくじ引きで expo-av 側のリソース蓄積の懸念。

**対応**:
- `utils/SoundManager.ts`: reload 前に `sound.unloadAsync()` を呼ぶ。unloadAsync 自体の失敗は致命的でないので握りつぶす。

## テスト結果

\`\`\`
$ pnpm exec jest
Tests:       226 passed, 226 total   # +2 new cases

$ pnpm exec tsc --noEmit  # クリーン
$ pnpm lint               # クリーン
\`\`\`

## 影響範囲

- Web 版のおみくじ抽選画面と進捗オーバーレイの視覚体験が復活
- 効果音再生の長時間安定性が向上
- 両変更とも最小差分で振る舞いは改善方向のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)