### PR TITLE
refactor: state machine の drawFortune 副作用を useEffect に分離

### DIFF
--- a/hooks/__tests__/useAppStateMachine.test.ts
+++ b/hooks/__tests__/useAppStateMachine.test.ts
@@ -172,6 +172,68 @@ describe("useAppStateMachine", () => {
     expect(shakeCalls).toHaveLength(1);
   });
 
+  it("allows re-draw after handleReset (shakeStarted guard is cleared)", async () => {
+    const opts = defaultOptions();
+    const { result, rerender } = renderHook(
+      (p: ReturnType<typeof defaultOptions>) => useAppStateMachine(p),
+      { initialProps: opts }
+    );
+
+    // Drive to RESULT
+    await act(async () => {
+      await result.current.handleShakeStart();
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1500);
+    });
+    act(() => jest.advanceTimersByTime(3500));
+    act(() => jest.advanceTimersByTime(2000));
+    expect(result.current.appState).toBe("RESULT");
+    expect(opts.drawFortune).toHaveBeenCalledTimes(1);
+
+    // Reset back to IDLE
+    act(() => {
+      result.current.handleReset();
+    });
+    expect(result.current.appState).toBe("IDLE");
+
+    // Simulate "next day" via prop change (hasDrawnToday false, hasFortune false)
+    rerender({ ...opts, hasDrawnToday: false, hasFortune: false });
+
+    // Second shake should fire cleanly
+    await act(async () => {
+      await result.current.handleShakeStart();
+    });
+    expect(result.current.appState).toBe("SHAKING");
+    await act(async () => {
+      jest.advanceTimersByTime(1500);
+    });
+    expect(result.current.appState).toBe("DRAWING");
+    expect(opts.drawFortune).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancels pending drawFortune transition when unmounted during SHAKING", async () => {
+    const opts = defaultOptions();
+    const { result, unmount } = renderHook(() => useAppStateMachine(opts));
+
+    await act(async () => {
+      await result.current.handleShakeStart();
+    });
+    expect(result.current.appState).toBe("SHAKING");
+
+    // Unmount before the 1500ms timer fires
+    unmount();
+
+    // Advance timer; effect cleanup must have cleared it, so no unhandled dispatch
+    await act(async () => {
+      jest.advanceTimersByTime(1500);
+    });
+
+    // drawFortune should not have been called after unmount cleanup
+    // (The cancellation guard short-circuits before the dispatch / haptic.)
+    expect(opts.drawFortune).not.toHaveBeenCalled();
+  });
+
   it("uses reduced durations when reducedMotion is true", async () => {
     const opts = { ...defaultOptions(), reducedMotion: true };
     const { result } = renderHook(() => useAppStateMachine(opts));

--- a/hooks/useAppStateMachine.ts
+++ b/hooks/useAppStateMachine.ts
@@ -56,19 +56,20 @@ export function useAppStateMachine({
   hasFortune,
 }: UseAppStateMachineOptions) {
   const [appState, dispatch] = useReducer(appStateReducer, "IDLE");
-  const shakeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // 同一フレーム内の多重発火（連打・センサー + タップ同時発火）を同期的に防ぐ。
+  // useReducer の state 反映は非同期のため、appState ガードだけでは不十分。
+  const shakeStartedRef = useRef(false);
 
   const drawingDuration = reducedMotion ? REDUCED_DRAWING_DURATION_MS : DRAWING_DURATION_MS;
   const revealingDuration = reducedMotion ? REDUCED_REVEALING_DURATION_MS : REVEALING_DURATION_MS;
 
   // --- Actions ---
 
-  const handleShakeStart = useCallback(async () => {
+  const handleShakeStart = useCallback(() => {
     if (appState !== "IDLE" || hasDrawnToday) return;
-    // useReducer の state 反映は非同期のため、appState ガードだけでは
-    // 同一フレーム内の多重呼び出し（連打・センサー + タップ同時発火）を防げない。
-    // 保留中タイマーの有無を同期的にチェックし、drawFortune の二重実行を防ぐ。
-    if (shakeTimerRef.current) return;
+    if (shakeStartedRef.current) return;
+    shakeStartedRef.current = true;
 
     triggerHaptic(
       { type: "impact", style: Haptics.ImpactFeedbackStyle.Medium },
@@ -78,18 +79,7 @@ export function useAppStateMachine({
 
     dispatch({ type: "START_SHAKE" });
     playSound("shake");
-
-    shakeTimerRef.current = setTimeout(async () => {
-      shakeTimerRef.current = null;
-      await drawFortune();
-      dispatch({ type: "START_DRAWING" });
-      triggerHaptic(
-        { type: "impact", style: Haptics.ImpactFeedbackStyle.Light },
-        false,
-        reducedMotion
-      );
-    }, SHAKING_DURATION_MS);
-  }, [appState, drawFortune, hasDrawnToday, playSound, reducedMotion]);
+  }, [appState, hasDrawnToday, playSound, reducedMotion]);
 
   const handleResultView = useCallback(() => {
     if (hasFortune) {
@@ -103,6 +93,13 @@ export function useAppStateMachine({
   }, [resetFortune]);
 
   // --- Side effects driven by state ---
+
+  // Reset the double-fire guard whenever we return to IDLE (enables re-draw after RESET).
+  useEffect(() => {
+    if (appState === "IDLE") {
+      shakeStartedRef.current = false;
+    }
+  }, [appState]);
 
   // SHAKING: periodic haptic feedback
   useEffect(() => {
@@ -118,6 +115,28 @@ export function useAppStateMachine({
 
     return () => clearInterval(intervalId);
   }, [appState, reducedMotion]);
+
+  // SHAKING → DRAWING (timer owns the drawFortune side effect)
+  useEffect(() => {
+    if (appState !== "SHAKING") return;
+
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      await drawFortune();
+      if (cancelled) return;
+      dispatch({ type: "START_DRAWING" });
+      triggerHaptic(
+        { type: "impact", style: Haptics.ImpactFeedbackStyle.Light },
+        false,
+        reducedMotion
+      );
+    }, SHAKING_DURATION_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [appState, drawFortune, reducedMotion]);
 
   // DRAWING → REVEALING (auto-advance)
   useEffect(() => {
@@ -146,16 +165,6 @@ export function useAppStateMachine({
 
     return () => clearTimeout(timer);
   }, [appState, playSound, revealingDuration]);
-
-  // Cleanup shake timer on unmount
-  useEffect(() => {
-    return () => {
-      if (shakeTimerRef.current) {
-        clearTimeout(shakeTimerRef.current);
-        shakeTimerRef.current = null;
-      }
-    };
-  }, []);
 
   return {
     appState,

--- a/hooks/useOmikujiLogic.ts
+++ b/hooks/useOmikujiLogic.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect } from "react";
+import Constants from "expo-constants";
 import { OmikujiResult } from "../types/omikuji";
 import { drawOmikuji } from "../utils/omikujiLogic";
 import {
@@ -58,6 +59,12 @@ export const useOmikujiLogic = () => {
   }, [hasDrawnToday]);
 
   const debugResetDailyLimit = useCallback(async () => {
+    // Defense-in-depth: no-op in production. __DEV__ is false in production builds;
+    // the appVariant check also blocks preview-style builds that somehow ship with __DEV__ true.
+    if (!__DEV__) return;
+    const variant = Constants.expoConfig?.extra?.appVariant;
+    if (variant === "production") return;
+
     await clearHistory();
     setHasDrawnToday(false);
     setFortune(null);


### PR DESCRIPTION
## Summary
- `useAppStateMachine` の SHAKING→DRAWING 遷移を `setTimeout` 直打ちから `appState` 駆動の `useEffect` に移し、reducer を時間遷移のみの責務に戻す
- 二重発火ガードを `shakeTimerRef` から `shakeStartedRef` に改め、IDLE 復帰時に自動クリア。`useEffect` cleanup で unmount 時のぶら下がり dispatch も防止
- `debugResetDailyLimit` に `!__DEV__` + `appVariant === "production"` の二段 gate を追加し、production bundle では no-op に

## 背景
アーキテクチャ改善プラン（Phase 0 PR1）の一部。副作用と状態遷移が reducer callback 内で混線していた箇所を、React 標準のライフサイクルに沿った形へ整える。

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec jest` 232/232 passed（state machine 10→12）
- [x] `pnpm lint` clean
- [x] 追加テスト: unmount 時の drawFortune キャンセル / RESET 後の再 draw 可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)