### PR TITLE
test(patterns): patterns カバレッジ追加 + 履歴ペイロード型バリデーション

### DIFF
--- a/components/patterns/__tests__/IdleRitualPattern.test.tsx
+++ b/components/patterns/__tests__/IdleRitualPattern.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import { IdleRitualPattern } from "../IdleRitualPattern";
+
+describe("IdleRitualPattern", () => {
+  it("shows the 'draw' copy and CTA when the user has not drawn today", () => {
+    const onDraw = jest.fn();
+    const onShowResult = jest.fn();
+    const { getByText, getByRole, queryByRole } = render(
+      <IdleRitualPattern hasDrawnToday={false} onDraw={onDraw} onShowResult={onShowResult} />
+    );
+
+    expect(getByText(/静かに息を整えて/)).toBeTruthy();
+    expect(getByRole("button", { name: "おみくじを引く" })).toBeTruthy();
+    expect(queryByRole("button", { name: "結果をもう一度見る" })).toBeNull();
+  });
+
+  it("invokes onDraw when the draw CTA is pressed", () => {
+    const onDraw = jest.fn();
+    const onShowResult = jest.fn();
+    const { getByRole } = render(
+      <IdleRitualPattern hasDrawnToday={false} onDraw={onDraw} onShowResult={onShowResult} />
+    );
+
+    fireEvent.press(getByRole("button", { name: "おみくじを引く" }));
+
+    expect(onDraw).toHaveBeenCalledTimes(1);
+    expect(onShowResult).not.toHaveBeenCalled();
+  });
+
+  it("switches to the 'review' copy and CTA once drawn today", () => {
+    const onDraw = jest.fn();
+    const onShowResult = jest.fn();
+    const { getByText, getByRole, queryByRole } = render(
+      <IdleRitualPattern hasDrawnToday={true} onDraw={onDraw} onShowResult={onShowResult} />
+    );
+
+    expect(getByText(/本日の運勢はすでに授かっています/)).toBeTruthy();
+    expect(getByRole("button", { name: "結果をもう一度見る" })).toBeTruthy();
+    expect(queryByRole("button", { name: "おみくじを引く" })).toBeNull();
+  });
+
+  it("invokes onShowResult when the review CTA is pressed", () => {
+    const onDraw = jest.fn();
+    const onShowResult = jest.fn();
+    const { getByRole } = render(
+      <IdleRitualPattern hasDrawnToday={true} onDraw={onDraw} onShowResult={onShowResult} />
+    );
+
+    fireEvent.press(getByRole("button", { name: "結果をもう一度見る" }));
+
+    expect(onShowResult).toHaveBeenCalledTimes(1);
+    expect(onDraw).not.toHaveBeenCalled();
+  });
+});

--- a/components/patterns/__tests__/ResultPattern.test.tsx
+++ b/components/patterns/__tests__/ResultPattern.test.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Share } from "react-native";
+import { render } from "@testing-library/react-native";
+import { ResultPattern } from "../ResultPattern";
+import { OmikujiResult } from "../../../types/omikuji";
+
+jest.mock("react-native-view-shot", () => ({
+  captureRef: jest.fn(() => Promise.reject(new Error("capture failed"))),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { returnObjects?: boolean }) => {
+      const translations: Record<string, string | string[]> = {
+        "fortune.shareTitle": "おみくじをシェア",
+        "fortune.levels.daikichi": "大吉",
+        "fortune.messages.daikichi": ["最高の運気です。新しいことに挑戦するチャンス！"],
+        "fortune.detailLabels.wish": "願望",
+        "fortune.details.daikichi.wish": "思うがままに叶うでしょう。",
+      };
+      const value = translations[key];
+      if (options?.returnObjects && Array.isArray(value)) return value;
+      return value ?? key;
+    },
+  }),
+}));
+
+jest.mock("../../design-system/MotionView", () => {
+  const { View } = require("react-native");
+  return { MotionView: View };
+});
+
+jest.spyOn(Share, "share").mockImplementation(() => Promise.resolve({ action: "sharedAction" }));
+
+describe("ResultPattern", () => {
+  const fortune: OmikujiResult = {
+    id: "test-1",
+    type: "omikuji",
+    level: "daikichi",
+    messageIndex: 0,
+    image: { uri: "test.png" },
+    color: "#FFD700",
+    createdAt: 1234567890,
+  };
+
+  it("renders a fortune title derived from i18n", () => {
+    const onReset = jest.fn();
+    const { getByText } = render(<ResultPattern fortune={fortune} onReset={onReset} />);
+    expect(getByText("大吉")).toBeTruthy();
+  });
+
+  it("renders without throwing when reducedMotion is enabled", () => {
+    const onReset = jest.fn();
+    expect(() =>
+      render(<ResultPattern fortune={fortune} onReset={onReset} reducedMotion />)
+    ).not.toThrow();
+  });
+});

--- a/components/patterns/__tests__/ShakingPattern.test.tsx
+++ b/components/patterns/__tests__/ShakingPattern.test.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { ShakingPattern } from "../ShakingPattern";
+
+describe("ShakingPattern", () => {
+  it("renders the ritual prompt text", () => {
+    const { getByText } = render(<ShakingPattern />);
+    expect(getByText("念を込めて...")).toBeTruthy();
+  });
+
+  it("renders with reducedMotion without crashing", () => {
+    const { getByText } = render(<ShakingPattern reducedMotion />);
+    expect(getByText("念を込めて...")).toBeTruthy();
+  });
+});

--- a/e2e/web/app.spec.ts
+++ b/e2e/web/app.spec.ts
@@ -32,6 +32,25 @@ test.describe("Digital Omikuji Web", () => {
     });
   });
 
+  test("result overlay is exposed as a modal dialog (focus trap attributes)", async ({ page }) => {
+    await gotoRoute(page, "/");
+
+    const drawButton = page.getByRole("button", { name: "おみくじを引く" });
+    await expect(drawButton).toBeVisible({ timeout: 15000 });
+    await drawButton.click();
+
+    // Wait for the result overlay (the only one with user-actionable focusables)
+    await expect(page.getByText(/大吉|中吉|小吉|末吉|凶|吉/).first()).toBeVisible({
+      timeout: 20000,
+    });
+
+    // ExperienceScreenTemplate should have tagged the overlay container as
+    // a modal dialog for assistive tech + keyboard focus management.
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute("aria-modal", "true");
+  });
+
   test("history direct entry returns to home", async ({ page }) => {
     await gotoRoute(page, "/history");
 

--- a/types/__tests__/omikuji.test.ts
+++ b/types/__tests__/omikuji.test.ts
@@ -1,4 +1,4 @@
-import { isOmikujiResult, OmikujiResult, FortuneResult } from "../omikuji";
+import { isFortuneLevel, isOmikujiResult, OmikujiResult, FortuneResult } from "../omikuji";
 
 describe("omikuji type guards", () => {
   const omikujiResult: OmikujiResult = {
@@ -26,6 +26,22 @@ describe("omikuji type guards", () => {
         fail("Expected omikuji result");
       }
     });
+  });
+
+  describe("isFortuneLevel", () => {
+    it.each(["daikichi", "chukichi", "shokichi", "kichi", "suekichi", "kyo", "daikyo"])(
+      "returns true for known level %s",
+      (level) => {
+        expect(isFortuneLevel(level)).toBe(true);
+      }
+    );
+
+    it.each([null, undefined, 0, "", "super-kichi", "Daikichi", {}])(
+      "returns false for invalid input %p",
+      (value) => {
+        expect(isFortuneLevel(value)).toBe(false);
+      }
+    );
   });
 
   describe("OmikujiResult", () => {

--- a/types/omikuji.ts
+++ b/types/omikuji.ts
@@ -25,6 +25,23 @@ export type FortuneLevel =
   | "kyo"
   | "daikyo";
 
+const FORTUNE_LEVELS: readonly FortuneLevel[] = [
+  "daikichi",
+  "chukichi",
+  "shokichi",
+  "kichi",
+  "suekichi",
+  "kyo",
+  "daikyo",
+];
+
+/**
+ * 型ガード: 値が FortuneLevel union のいずれかであるかを判定する。
+ */
+export function isFortuneLevel(value: unknown): value is FortuneLevel {
+  return typeof value === "string" && (FORTUNE_LEVELS as readonly string[]).includes(value);
+}
+
 /**
  * おみくじの結果。
  * BaseFortune を拡張し、おみくじ固有のフィールドを持つ。

--- a/utils/HistoryStorage.ts
+++ b/utils/HistoryStorage.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { FortuneResult, OmikujiResult } from "../types/omikuji";
+import type { ImageSourcePropType } from "react-native";
+import { FortuneResult, OmikujiResult, isFortuneLevel } from "../types/omikuji";
 import { captureException } from "./sentry";
 
 /**
@@ -27,15 +28,37 @@ export type HistoryEntry = FortuneResult;
 /**
  * レガシー履歴データ（type フィールドがない古いデータ）を
  * 新しい BaseFortune 形式にマイグレートする。
+ *
+ * 壊れた / 未知形式のペイロードは `null` を返し、呼び出し元で除外される。
+ * 以前は `as Partial<OmikujiResult>` で素通ししていたが、各フィールドを型
+ * ガードで検証してから明示的に OmikujiResult を組み立てる。
  */
 function migrateLegacyEntry(raw: unknown): HistoryEntry | null {
   if (typeof raw !== "object" || raw === null) return null;
-  const entry = raw as Partial<OmikujiResult> & { type?: string };
-  if (!entry.id || !entry.level || typeof entry.createdAt !== "number") return null;
-  return {
-    ...entry,
-    type: entry.type === "omikuji" ? "omikuji" : "omikuji",
-  } as OmikujiResult;
+  const r = raw as Record<string, unknown>;
+
+  // type は存在する場合のみ "omikuji" を許可（将来の占い種別は未対応）
+  if (r.type !== undefined && r.type !== "omikuji") return null;
+
+  if (typeof r.id !== "string" || r.id.length === 0) return null;
+  if (!isFortuneLevel(r.level)) return null;
+  if (typeof r.messageIndex !== "number" || !Number.isFinite(r.messageIndex)) return null;
+  if (typeof r.color !== "string") return null;
+  if (typeof r.createdAt !== "number" || !Number.isFinite(r.createdAt)) return null;
+  if (r.image == null) return null;
+
+  const result: OmikujiResult = {
+    id: r.id,
+    type: "omikuji",
+    level: r.level,
+    messageIndex: r.messageIndex,
+    // ImageSourcePropType は number | { uri: string } | array 等の union。
+    // 構造的検証は non-null のみ（各形式は RN 側 Image コンポーネントが扱う）
+    image: r.image as ImageSourcePropType,
+    color: r.color,
+    createdAt: r.createdAt,
+  };
+  return result;
 }
 
 /**

--- a/utils/__tests__/HistoryStorage.test.ts
+++ b/utils/__tests__/HistoryStorage.test.ts
@@ -115,6 +115,73 @@ describe("HistoryStorage", () => {
     expect(savedData[49].id).toBe("existing-48");
   });
 
+  it("drops entries whose payload fails shape validation", async () => {
+    // Corrupted mix: unknown level, non-numeric messageIndex, missing image,
+    // and one valid legacy entry that should survive.
+    const mixedPayload = [
+      {
+        id: "bad-1",
+        level: "not-a-level",
+        messageIndex: 0,
+        image: { uri: "x" },
+        color: "#000",
+        createdAt: 1,
+      },
+      {
+        id: "bad-2",
+        level: "daikichi",
+        messageIndex: "zero",
+        image: { uri: "x" },
+        color: "#000",
+        createdAt: 1,
+      },
+      { id: "bad-3", level: "daikichi", messageIndex: 0, color: "#000", createdAt: 1 }, // no image
+      { id: "bad-4", level: "daikichi", messageIndex: 0, image: { uri: "x" }, color: "#000" }, // no createdAt
+      {
+        id: "",
+        level: "daikichi",
+        messageIndex: 0,
+        image: { uri: "x" },
+        color: "#000",
+        createdAt: 1,
+      }, // empty id
+      {
+        id: "good",
+        level: "daikichi",
+        messageIndex: 0,
+        image: { uri: "x" },
+        color: "#000",
+        createdAt: 123,
+      },
+    ];
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(mixedPayload));
+
+    const result = await getHistory();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("good");
+    expect(result[0].type).toBe("omikuji");
+  });
+
+  it("rejects entries with unknown fortune type", async () => {
+    const payload = [
+      {
+        id: "tarot-1",
+        type: "tarot",
+        level: "daikichi",
+        messageIndex: 0,
+        image: { uri: "x" },
+        color: "#000",
+        createdAt: 1,
+      },
+    ];
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(payload));
+
+    const result = await getHistory();
+
+    expect(result).toEqual([]);
+  });
+
   it("manages last draw date", async () => {
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
     expect(await getLastDrawDate()).toBeNull();


### PR DESCRIPTION
## Summary
- \`components/patterns/\` 3 本（IdleRitualPattern / ShakingPattern / ResultPattern）に semantic query ベースのユニットテストを追加。テストが 0 件だったパターン層をリグレッションネットに載せる
- \`types/omikuji.ts\` に \`isFortuneLevel\` 型ガードを追加
- \`utils/HistoryStorage.ts\` の \`migrateLegacyEntry\` を書き換え、\`as Partial<OmikujiResult>\` の cast を撤廃。フィールド毎に型ガードで検証してから明示的に \`OmikujiResult\` を組み立てる
- \`HistoryStorage.test.ts\` に壊れた payload の drop / 未知の type の reject ケースを追加
- \`e2e/web/app.spec.ts\` に結果オーバーレイの \`role="dialog"\` / \`aria-modal="true"\` を検証する Playwright ケースを追加

## 背景
アーキテクチャ改善プラン Phase 0 PR3。テスト欠落と型キャスト依存の脆さを解消する最小セット。Web 側 focus trap 挙動は unit test ではなく Playwright で外形確認するスタンス。

## Test plan
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`pnpm exec jest\` 254/254 passed（232→254、追加 22）
- [x] \`pnpm lint\` clean
- [ ] \`pnpm exec playwright test\` で focus trap アサーションが通ること（ローカル / CI のいずれかで実行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)