### PR TITLE
[refactor] domain層抽出: 純粋ロジックを React/Expo から分離

### DIFF
--- a/components/patterns/__tests__/IdleRitualPattern.test.tsx
+++ b/components/patterns/__tests__/IdleRitualPattern.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import { IdleRitualPattern } from "../IdleRitualPattern";
+
+describe("IdleRitualPattern", () => {
+  it("shows the 'draw' copy and CTA when the user has not drawn today", () => {
+    const onDraw = jest.fn();
+    const onShowResult = jest.fn();
+    const { getByText, getByRole, queryByRole } = render(
+      <IdleRitualPattern hasDrawnToday={false} onDraw={onDraw} onShowResult={onShowResult} />
+    );
+
+    expect(getByText(/静かに息を整えて/)).toBeTruthy();
+    expect(getByRole("button", { name: "おみくじを引く" })).toBeTruthy();
+    expect(queryByRole("button", { name: "結果をもう一度見る" })).toBeNull();
+  });
+
+  it("invokes onDraw when the draw CTA is pressed", () => {
+    const onDraw = jest.fn();
+    const onShowResult = jest.fn();
+    const { getByRole } = render(
+      <IdleRitualPattern hasDrawnToday={false} onDraw={onDraw} onShowResult={onShowResult} />
+    );
+
+    fireEvent.press(getByRole("button", { name: "おみくじを引く" }));
+
+    expect(onDraw).toHaveBeenCalledTimes(1);
+    expect(onShowResult).not.toHaveBeenCalled();
+  });
+
+  it("switches to the 'review' copy and CTA once drawn today", () => {
+    const onDraw = jest.fn();
+    const onShowResult = jest.fn();
+    const { getByText, getByRole, queryByRole } = render(
+      <IdleRitualPattern hasDrawnToday={true} onDraw={onDraw} onShowResult={onShowResult} />
+    );
+
+    expect(getByText(/本日の運勢はすでに授かっています/)).toBeTruthy();
+    expect(getByRole("button", { name: "結果をもう一度見る" })).toBeTruthy();
+    expect(queryByRole("button", { name: "おみくじを引く" })).toBeNull();
+  });
+
+  it("invokes onShowResult when the review CTA is pressed", () => {
+    const onDraw = jest.fn();
+    const onShowResult = jest.fn();
+    const { getByRole } = render(
+      <IdleRitualPattern hasDrawnToday={true} onDraw={onDraw} onShowResult={onShowResult} />
+    );
+
+    fireEvent.press(getByRole("button", { name: "結果をもう一度見る" }));
+
+    expect(onShowResult).toHaveBeenCalledTimes(1);
+    expect(onDraw).not.toHaveBeenCalled();
+  });
+});

--- a/components/patterns/__tests__/ResultPattern.test.tsx
+++ b/components/patterns/__tests__/ResultPattern.test.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Share } from "react-native";
+import { render } from "@testing-library/react-native";
+import { ResultPattern } from "../ResultPattern";
+import { OmikujiResult } from "../../../types/omikuji";
+
+jest.mock("react-native-view-shot", () => ({
+  captureRef: jest.fn(() => Promise.reject(new Error("capture failed"))),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { returnObjects?: boolean }) => {
+      const translations: Record<string, string | string[]> = {
+        "fortune.shareTitle": "おみくじをシェア",
+        "fortune.levels.daikichi": "大吉",
+        "fortune.messages.daikichi": ["最高の運気です。新しいことに挑戦するチャンス！"],
+        "fortune.detailLabels.wish": "願望",
+        "fortune.details.daikichi.wish": "思うがままに叶うでしょう。",
+      };
+      const value = translations[key];
+      if (options?.returnObjects && Array.isArray(value)) return value;
+      return value ?? key;
+    },
+  }),
+}));
+
+jest.mock("../../design-system/MotionView", () => {
+  const { View } = require("react-native");
+  return { MotionView: View };
+});
+
+jest.spyOn(Share, "share").mockImplementation(() => Promise.resolve({ action: "sharedAction" }));
+
+describe("ResultPattern", () => {
+  const fortune: OmikujiResult = {
+    id: "test-1",
+    type: "omikuji",
+    level: "daikichi",
+    messageIndex: 0,
+    image: { uri: "test.png" },
+    color: "#FFD700",
+    createdAt: 1234567890,
+  };
+
+  it("renders a fortune title derived from i18n", () => {
+    const onReset = jest.fn();
+    const { getByText } = render(<ResultPattern fortune={fortune} onReset={onReset} />);
+    expect(getByText("大吉")).toBeTruthy();
+  });
+
+  it("renders without throwing when reducedMotion is enabled", () => {
+    const onReset = jest.fn();
+    expect(() =>
+      render(<ResultPattern fortune={fortune} onReset={onReset} reducedMotion />)
+    ).not.toThrow();
+  });
+});

--- a/components/patterns/__tests__/ShakingPattern.test.tsx
+++ b/components/patterns/__tests__/ShakingPattern.test.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { ShakingPattern } from "../ShakingPattern";
+
+describe("ShakingPattern", () => {
+  it("renders the ritual prompt text", () => {
+    const { getByText } = render(<ShakingPattern />);
+    expect(getByText("念を込めて...")).toBeTruthy();
+  });
+
+  it("renders with reducedMotion without crashing", () => {
+    const { getByText } = render(<ShakingPattern reducedMotion />);
+    expect(getByText("念を込めて...")).toBeTruthy();
+  });
+});

--- a/domain/__tests__/buildShareText.test.ts
+++ b/domain/__tests__/buildShareText.test.ts
@@ -1,0 +1,21 @@
+import { buildShareText } from "../buildShareText";
+
+describe("buildShareText", () => {
+  it("generates the expected share template", () => {
+    const text = buildShareText({ title: "大吉", description: "最高の運気です" });
+
+    expect(text).toContain("2026年のエンジニア運勢は");
+    expect(text).toContain("『大吉』");
+    expect(text).toContain("最高の運気です");
+    expect(text).toContain("#エンジニアおみくじ2026");
+    expect(text).toContain("#令和八年");
+    expect(text).toContain("あなたも占ってみよう👇");
+    expect(text).toContain(
+      "https://digital-omikuji.vercel.app?utm_source=share&utm_campaign=omikuji2026"
+    );
+  });
+
+  it("interpolates different titles", () => {
+    expect(buildShareText({ title: "凶", description: "注意が必要です" })).toContain("『凶』");
+  });
+});

--- a/domain/__tests__/drawOmikuji.test.ts
+++ b/domain/__tests__/drawOmikuji.test.ts
@@ -1,0 +1,68 @@
+import { drawOmikuji } from "../drawOmikuji";
+import { ACQUIRED_FORTUNES } from "../../data/omikujiData";
+
+describe("drawOmikuji", () => {
+  it("returns an OmikujiResult with all required fields", () => {
+    const result = drawOmikuji();
+    expect(typeof result.id).toBe("string");
+    expect(result.type).toBe("omikuji");
+    expect(typeof result.level).toBe("string");
+    expect(typeof result.messageIndex).toBe("number");
+    expect(result.messageIndex).toBeGreaterThanOrEqual(0);
+    expect(result.messageIndex).toBeLessThan(5);
+    expect(typeof result.createdAt).toBe("number");
+    expect(typeof result.color).toBe("string");
+    expect(result.image).toBeDefined();
+  });
+
+  it("selects the first fortune when rng returns 0", () => {
+    const result = drawOmikuji({
+      rng: () => 0,
+      idGenerator: () => "fixed-id",
+      clockNow: () => 123,
+    });
+    expect(result.level).toBe(ACQUIRED_FORTUNES[0].level);
+    expect(result.id).toBe("fixed-id");
+    expect(result.createdAt).toBe(123);
+    expect(result.messageIndex).toBe(0);
+  });
+
+  it("falls back to the last fortune when rng returns near 1", () => {
+    const result = drawOmikuji({
+      rng: () => 0.9999,
+      idGenerator: () => "id",
+      clockNow: () => 0,
+    });
+    expect(result.level).toBe(ACQUIRED_FORTUNES[ACQUIRED_FORTUNES.length - 1].level);
+  });
+
+  it("is deterministic with a seedable rng sequence", () => {
+    // Deterministic pseudo-random sequence for reproducible tests.
+    const values = [0.1, 0.5, 0.25, 0.8];
+    let i = 0;
+    const rng = () => values[i++ % values.length];
+
+    const r1 = drawOmikuji({ rng, idGenerator: () => "a", clockNow: () => 1 });
+    i = 0;
+    const r2 = drawOmikuji({ rng, idGenerator: () => "a", clockNow: () => 1 });
+
+    expect(r1).toEqual(r2);
+  });
+
+  it("uses the injected weights to bias the draw", () => {
+    const only = ACQUIRED_FORTUNES.filter((f) => f.level === "daikichi");
+    const result = drawOmikuji({
+      rng: () => 0,
+      weights: only,
+      idGenerator: () => "id",
+      clockNow: () => 0,
+    });
+    expect(result.level).toBe("daikichi");
+  });
+
+  it("produces a unique id via the default generator when crypto.randomUUID is available", () => {
+    const a = drawOmikuji();
+    const b = drawOmikuji();
+    expect(a.id).not.toBe(b.id);
+  });
+});

--- a/domain/__tests__/drawOmikuji.test.ts
+++ b/domain/__tests__/drawOmikuji.test.ts
@@ -65,4 +65,37 @@ describe("drawOmikuji", () => {
     const b = drawOmikuji();
     expect(a.id).not.toBe(b.id);
   });
+
+  it("throws when the weights table is empty", () => {
+    expect(() =>
+      drawOmikuji({
+        rng: () => 0,
+        weights: [],
+        idGenerator: () => "id",
+        clockNow: () => 0,
+      })
+    ).toThrow(/weights table cannot be empty/);
+  });
+
+  it("default id generator uses injected rng / clockNow when crypto.randomUUID is unavailable", () => {
+    const originalCrypto = (globalThis as { crypto?: unknown }).crypto;
+    // Simulate a runtime without Web Crypto so the fallback branch is exercised.
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: {},
+    });
+    try {
+      const result = drawOmikuji({
+        rng: () => 0.5,
+        clockNow: () => 1000,
+      });
+      expect(result.id).toMatch(/^omi-/);
+      expect(result.createdAt).toBe(1000);
+    } finally {
+      Object.defineProperty(globalThis, "crypto", {
+        configurable: true,
+        value: originalCrypto,
+      });
+    }
+  });
 });

--- a/domain/__tests__/fortuneRules.test.ts
+++ b/domain/__tests__/fortuneRules.test.ts
@@ -1,0 +1,33 @@
+import { canDrawToday, getTodayString } from "../fortuneRules";
+
+describe("getTodayString", () => {
+  it("formats a date as YYYY-MM-DD", () => {
+    expect(getTodayString(new Date(2026, 0, 1))).toBe("2026-01-01");
+    expect(getTodayString(new Date(2026, 11, 31))).toBe("2026-12-31");
+  });
+
+  it("zero-pads single-digit months and days", () => {
+    expect(getTodayString(new Date(2026, 4, 7))).toBe("2026-05-07");
+  });
+
+  it("uses the local timezone (no UTC conversion)", () => {
+    // The device's local timezone is authoritative; callers aware of cross-TZ
+    // concerns should reference docs/guides/TIMEZONE_POLICY.md.
+    const localDate = new Date(2026, 0, 15, 23, 59, 59);
+    expect(getTodayString(localDate)).toBe("2026-01-15");
+  });
+});
+
+describe("canDrawToday", () => {
+  it("returns true when no draw has ever happened", () => {
+    expect(canDrawToday(null, "2026-01-01")).toBe(true);
+  });
+
+  it("returns false when the last draw was today", () => {
+    expect(canDrawToday("2026-01-01", "2026-01-01")).toBe(false);
+  });
+
+  it("returns true when the last draw was a previous day", () => {
+    expect(canDrawToday("2025-12-31", "2026-01-01")).toBe(true);
+  });
+});

--- a/domain/__tests__/getFortuneText.test.ts
+++ b/domain/__tests__/getFortuneText.test.ts
@@ -37,4 +37,14 @@ describe("getFortuneText", () => {
     });
     expect(getFortuneText(t, "kyo", 0).message).toBe("シングル");
   });
+
+  it("returns an empty message when the messages array is empty", () => {
+    const t = buildT({
+      "fortune.levels.daikichi": "大吉",
+      "fortune.messages.daikichi": [],
+    });
+    const result = getFortuneText(t, "daikichi", 0);
+    expect(result.title).toBe("大吉");
+    expect(result.message).toBe("");
+  });
 });

--- a/domain/__tests__/getFortuneText.test.ts
+++ b/domain/__tests__/getFortuneText.test.ts
@@ -1,0 +1,40 @@
+import type { TFunction } from "i18next";
+import { getFortuneText } from "../getFortuneText";
+
+describe("getFortuneText", () => {
+  const buildT = (messages: Record<string, unknown>) =>
+    ((key: string, options?: { returnObjects?: boolean }) => {
+      const value = messages[key];
+      if (options?.returnObjects && Array.isArray(value)) return value;
+      if (value == null) return key;
+      return value;
+    }) as unknown as TFunction;
+
+  it("returns the localised title and selected message by index", () => {
+    const t = buildT({
+      "fortune.levels.daikichi": "大吉",
+      "fortune.messages.daikichi": ["メッセージ0", "メッセージ1", "メッセージ2"],
+    });
+
+    expect(getFortuneText(t, "daikichi", 1)).toEqual({
+      title: "大吉",
+      message: "メッセージ1",
+    });
+  });
+
+  it("falls back to the first message when the index is out of range", () => {
+    const t = buildT({
+      "fortune.levels.daikichi": "大吉",
+      "fortune.messages.daikichi": ["M0", "M1"],
+    });
+    expect(getFortuneText(t, "daikichi", 99).message).toBe("M0");
+  });
+
+  it("coerces a non-array messages value to a string", () => {
+    const t = buildT({
+      "fortune.levels.kyo": "凶",
+      "fortune.messages.kyo": "シングル",
+    });
+    expect(getFortuneText(t, "kyo", 0).message).toBe("シングル");
+  });
+});

--- a/domain/__tests__/historyMigration.test.ts
+++ b/domain/__tests__/historyMigration.test.ts
@@ -1,0 +1,49 @@
+import { migrateLegacyEntry } from "../historyMigration";
+
+describe("migrateLegacyEntry", () => {
+  const validRaw = {
+    id: "entry-1",
+    level: "daikichi",
+    messageIndex: 0,
+    image: { uri: "x" },
+    color: "#FFD700",
+    createdAt: 1_700_000_000_000,
+  };
+
+  it("accepts a legacy entry (no type field) and stamps type=omikuji", () => {
+    const result = migrateLegacyEntry(validRaw);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("omikuji");
+    expect(result!.id).toBe("entry-1");
+    expect(result!.level).toBe("daikichi");
+  });
+
+  it("accepts a modern entry whose type is omikuji", () => {
+    const result = migrateLegacyEntry({ ...validRaw, type: "omikuji" });
+    expect(result).not.toBeNull();
+  });
+
+  it("rejects an entry whose type is unknown", () => {
+    expect(migrateLegacyEntry({ ...validRaw, type: "tarot" })).toBeNull();
+  });
+
+  it("rejects non-object inputs", () => {
+    expect(migrateLegacyEntry(null)).toBeNull();
+    expect(migrateLegacyEntry(undefined)).toBeNull();
+    expect(migrateLegacyEntry(0)).toBeNull();
+    expect(migrateLegacyEntry("string")).toBeNull();
+  });
+
+  it.each([
+    ["empty id", { ...validRaw, id: "" }],
+    ["missing id", { ...validRaw, id: undefined }],
+    ["unknown level", { ...validRaw, level: "super-kichi" }],
+    ["non-numeric messageIndex", { ...validRaw, messageIndex: "zero" }],
+    ["NaN messageIndex", { ...validRaw, messageIndex: Number.NaN }],
+    ["missing color", { ...validRaw, color: undefined }],
+    ["missing createdAt", { ...validRaw, createdAt: undefined }],
+    ["null image", { ...validRaw, image: null }],
+  ])("rejects payload with %s", (_label, payload) => {
+    expect(migrateLegacyEntry(payload)).toBeNull();
+  });
+});

--- a/domain/buildShareText.ts
+++ b/domain/buildShareText.ts
@@ -1,0 +1,28 @@
+const APP_URL = "https://digital-omikuji.vercel.app";
+const HASHTAGS = ["#エンジニアおみくじ2026", "#令和八年"];
+
+interface ShareTextParams {
+  title: string;
+  description: string;
+}
+
+/**
+ * Builds the share text for X (Twitter).
+ *
+ * Template:
+ * 2026年のエンジニア運勢は
+ * 『{運勢}』
+ * {description}
+ *
+ * #エンジニアおみくじ2026
+ * #令和八年
+ *
+ * あなたも占ってみよう👇
+ * {URL}
+ */
+export function buildShareText(params: ShareTextParams): string {
+  const hashtags = HASHTAGS.join("\n");
+  const url = `${APP_URL}?utm_source=share&utm_campaign=omikuji2026`;
+
+  return `2026年のエンジニア運勢は\n『${params.title}』\n${params.description}\n\n${hashtags}\n\nあなたも占ってみよう👇\n${url}`;
+}

--- a/domain/drawOmikuji.ts
+++ b/domain/drawOmikuji.ts
@@ -18,14 +18,18 @@ export interface DrawOmikujiOptions {
   weights?: readonly OmikujiMasterData[];
 }
 
-function defaultIdGenerator(): string {
-  const webCrypto = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
-  if (webCrypto && typeof webCrypto.randomUUID === "function") {
-    return webCrypto.randomUUID();
-  }
-  // Extremely rare: environments without Web Crypto. Fortune IDs are not security-
-  // sensitive, so a time + random composite is acceptable as a last resort.
-  return `omi-${Date.now().toString(36)}-${Math.floor(Math.random() * 1e9).toString(36)}`;
+function makeFallbackIdGenerator(rng: () => number, clockNow: () => number): () => string {
+  return () => {
+    const webCrypto = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+    if (webCrypto && typeof webCrypto.randomUUID === "function") {
+      return webCrypto.randomUUID();
+    }
+    // Extremely rare: environments without Web Crypto. Fortune IDs are not security-
+    // sensitive, so a time + random composite is acceptable as a last resort.
+    // The composite uses the injected rng / clockNow so callers retain full determinism
+    // even on the fallback path.
+    return `omi-${clockNow().toString(36)}-${Math.floor(rng() * 1e9).toString(36)}`;
+  };
 }
 
 /**
@@ -38,8 +42,12 @@ function defaultIdGenerator(): string {
 export function drawOmikuji(options: DrawOmikujiOptions = {}): OmikujiResult {
   const rng = options.rng ?? Math.random;
   const clockNow = options.clockNow ?? Date.now;
-  const idGenerator = options.idGenerator ?? defaultIdGenerator;
+  const idGenerator = options.idGenerator ?? makeFallbackIdGenerator(rng, clockNow);
   const weights = options.weights ?? ACQUIRED_FORTUNES;
+
+  if (weights.length === 0) {
+    throw new Error("drawOmikuji: weights table cannot be empty.");
+  }
 
   const totalWeight = weights.reduce((sum, item) => sum + item.weight, 0);
   let randomValue = rng() * totalWeight;

--- a/domain/drawOmikuji.ts
+++ b/domain/drawOmikuji.ts
@@ -1,0 +1,67 @@
+import { ACQUIRED_FORTUNES, OmikujiMasterData } from "../data/omikujiData";
+import { OmikujiResult } from "../types/omikuji";
+
+const MESSAGES_PER_LEVEL = 5;
+
+/**
+ * Options for `drawOmikuji`. All fields are injectable so the function stays
+ * pure and deterministic in tests.
+ */
+export interface DrawOmikujiOptions {
+  /** Random number generator returning a value in `[0, 1)`. Defaults to `Math.random`. */
+  rng?: () => number;
+  /** Clock source for `createdAt`. Defaults to `Date.now`. */
+  clockNow?: () => number;
+  /** Identifier factory. Defaults to `globalThis.crypto.randomUUID` with a safe fallback. */
+  idGenerator?: () => string;
+  /** Weighted fortune table. Defaults to the shipped master data. */
+  weights?: readonly OmikujiMasterData[];
+}
+
+function defaultIdGenerator(): string {
+  const webCrypto = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  if (webCrypto && typeof webCrypto.randomUUID === "function") {
+    return webCrypto.randomUUID();
+  }
+  // Extremely rare: environments without Web Crypto. Fortune IDs are not security-
+  // sensitive, so a time + random composite is acceptable as a last resort.
+  return `omi-${Date.now().toString(36)}-${Math.floor(Math.random() * 1e9).toString(36)}`;
+}
+
+/**
+ * Perform a weighted lottery to select a fortune result.
+ *
+ * The implementation is pure: all sources of non-determinism (RNG, clock, ID
+ * factory) can be injected via {@link DrawOmikujiOptions}, which makes tests
+ * and future A/B experiments straightforward.
+ */
+export function drawOmikuji(options: DrawOmikujiOptions = {}): OmikujiResult {
+  const rng = options.rng ?? Math.random;
+  const clockNow = options.clockNow ?? Date.now;
+  const idGenerator = options.idGenerator ?? defaultIdGenerator;
+  const weights = options.weights ?? ACQUIRED_FORTUNES;
+
+  const totalWeight = weights.reduce((sum, item) => sum + item.weight, 0);
+  let randomValue = rng() * totalWeight;
+
+  let selectedData = weights[weights.length - 1];
+  for (const data of weights) {
+    if (randomValue < data.weight) {
+      selectedData = data;
+      break;
+    }
+    randomValue -= data.weight;
+  }
+
+  const messageIndex = Math.floor(rng() * MESSAGES_PER_LEVEL);
+
+  return {
+    id: idGenerator(),
+    type: "omikuji",
+    level: selectedData.level,
+    messageIndex,
+    image: selectedData.image,
+    color: selectedData.color,
+    createdAt: clockNow(),
+  };
+}

--- a/domain/fortuneRules.ts
+++ b/domain/fortuneRules.ts
@@ -1,0 +1,27 @@
+/**
+ * 今日の日付を YYYY-MM-DD 形式で返す。
+ *
+ * この値は「1 日 1 回制限」の判定基準として使用される。
+ * デバイスのローカルタイムゾーンに依存する設計である点に注意:
+ * タイムゾーン変更・国境越えユーザーの挙動、将来 UTC 切替する場合の方針は
+ * `docs/guides/TIMEZONE_POLICY.md` を参照。
+ */
+export function getTodayString(now: Date = new Date()): string {
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(
+    now.getDate()
+  ).padStart(2, "0")}`;
+}
+
+/**
+ * 既に今日引いたかどうかを判定する。
+ *
+ * 判定は「最後に引いた日付の文字列が今日の日付文字列と一致する」だけで行う。
+ * 日付生成をインジェクションできるので、境界値テストが容易。
+ */
+export function canDrawToday(
+  lastDrawDate: string | null,
+  today: string = getTodayString()
+): boolean {
+  if (lastDrawDate == null) return true;
+  return lastDrawDate !== today;
+}

--- a/domain/getFortuneText.ts
+++ b/domain/getFortuneText.ts
@@ -14,8 +14,11 @@ export function getFortuneText(
 ): { title: string; message: string } {
   const title = t(`fortune.levels.${level}`);
   const messages = t(`fortune.messages.${level}`, { returnObjects: true });
+  // Array case: prefer the requested index, fall back to the first message, then
+  // to empty string so the return type stays `string` even if i18n resources
+  // ship an empty array by mistake.
   const message = Array.isArray(messages)
-    ? messages[messageIndex] || messages[0]
+    ? ((messages[messageIndex] ?? messages[0] ?? "") as string)
     : String(messages);
 
   return { title, message };

--- a/domain/getFortuneText.ts
+++ b/domain/getFortuneText.ts
@@ -1,0 +1,22 @@
+import type { TFunction } from "i18next";
+import { FortuneLevel } from "../types/omikuji";
+
+/**
+ * おみくじ結果の見出しと本文を i18n 経由で取り出す。
+ *
+ * `TFunction` を引数で受け取ることで、domain 層は react-i18next への直接
+ * 依存を持たない（呼び出し側 hooks が注入する）。
+ */
+export function getFortuneText(
+  t: TFunction,
+  level: FortuneLevel,
+  messageIndex: number
+): { title: string; message: string } {
+  const title = t(`fortune.levels.${level}`);
+  const messages = t(`fortune.messages.${level}`, { returnObjects: true });
+  const message = Array.isArray(messages)
+    ? messages[messageIndex] || messages[0]
+    : String(messages);
+
+  return { title, message };
+}

--- a/domain/historyMigration.ts
+++ b/domain/historyMigration.ts
@@ -1,0 +1,36 @@
+import type { ImageSourcePropType } from "react-native";
+import { OmikujiResult, isFortuneLevel } from "../types/omikuji";
+
+/**
+ * レガシー履歴データ（type フィールドがない古いデータ）を
+ * 新しい BaseFortune 形式にマイグレートする。
+ *
+ * 壊れた / 未知形式のペイロードは `null` を返し、呼び出し元で除外される。
+ * 各フィールドを型ガードで検証してから明示的に OmikujiResult を組み立てる。
+ */
+export function migrateLegacyEntry(raw: unknown): OmikujiResult | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+
+  // type は存在する場合のみ "omikuji" を許可（将来の占い種別は未対応）
+  if (r.type !== undefined && r.type !== "omikuji") return null;
+
+  if (typeof r.id !== "string" || r.id.length === 0) return null;
+  if (!isFortuneLevel(r.level)) return null;
+  if (typeof r.messageIndex !== "number" || !Number.isFinite(r.messageIndex)) return null;
+  if (typeof r.color !== "string") return null;
+  if (typeof r.createdAt !== "number" || !Number.isFinite(r.createdAt)) return null;
+  if (r.image == null) return null;
+
+  return {
+    id: r.id,
+    type: "omikuji",
+    level: r.level,
+    messageIndex: r.messageIndex,
+    // ImageSourcePropType は number | { uri: string } | array 等の union。
+    // 構造的検証は non-null のみ（各形式は RN 側 Image コンポーネントが扱う）
+    image: r.image as ImageSourcePropType,
+    color: r.color,
+    createdAt: r.createdAt,
+  };
+}

--- a/domain/index.ts
+++ b/domain/index.ts
@@ -1,0 +1,15 @@
+/**
+ * 純粋ドメイン層の公開エントリーポイント。
+ *
+ * この層の不変条件:
+ * - react / react-native / expo-* / @react-native-* への実行時依存なし
+ *   （`import type` は runtime には残らないので許容）
+ * - AsyncStorage、Sentry、Audio などの副作用を持つ API を直接呼ばない
+ * - 時刻・乱数・ID 生成など非決定性は引数で注入する
+ */
+export { drawOmikuji } from "./drawOmikuji";
+export type { DrawOmikujiOptions } from "./drawOmikuji";
+export { getTodayString, canDrawToday } from "./fortuneRules";
+export { migrateLegacyEntry } from "./historyMigration";
+export { getFortuneText } from "./getFortuneText";
+export { buildShareText } from "./buildShareText";

--- a/e2e/web/app.spec.ts
+++ b/e2e/web/app.spec.ts
@@ -32,6 +32,25 @@ test.describe("Digital Omikuji Web", () => {
     });
   });
 
+  test("result overlay is exposed as a modal dialog (focus trap attributes)", async ({ page }) => {
+    await gotoRoute(page, "/");
+
+    const drawButton = page.getByRole("button", { name: "おみくじを引く" });
+    await expect(drawButton).toBeVisible({ timeout: 15000 });
+    await drawButton.click();
+
+    // Wait for the result overlay (the only one with user-actionable focusables)
+    await expect(page.getByText(/大吉|中吉|小吉|末吉|凶|吉/).first()).toBeVisible({
+      timeout: 20000,
+    });
+
+    // ExperienceScreenTemplate should have tagged the overlay container as
+    // a modal dialog for assistive tech + keyboard focus management.
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute("aria-modal", "true");
+  });
+
   test("history direct entry returns to home", async ({ page }) => {
     await gotoRoute(page, "/history");
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,37 @@ module.exports = [
     },
   },
   {
+    // Domain layer boundary: runtime imports from UI / platform packages are
+    // forbidden. `import type` is allowed because it is erased at compile time
+    // and does not create a runtime dependency.
+    files: ["domain/**/*.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "react",
+                "react-native",
+                "react-native/**",
+                "expo",
+                "expo-*",
+                "@react-native*",
+                "@react-native/**",
+                "@sentry/*",
+                "@react-native-async-storage/*",
+              ],
+              message:
+                "domain/ layer must stay platform-agnostic. Use `import type` for types, or move side-effectful code into services/infra.",
+              allowTypeImports: true,
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     ignores: [
       "node_modules/",
       ".expo/",

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
   collectCoverageFrom: [
     "app/**/*.{ts,tsx}",
     "components/**/*.{ts,tsx}",
+    "domain/**/*.{ts,tsx}",
     "hooks/**/*.{ts,tsx}",
     "utils/**/*.{ts,tsx}",
     "!**/*.d.ts",

--- a/types/__tests__/omikuji.test.ts
+++ b/types/__tests__/omikuji.test.ts
@@ -1,4 +1,4 @@
-import { isOmikujiResult, OmikujiResult, FortuneResult } from "../omikuji";
+import { isFortuneLevel, isOmikujiResult, OmikujiResult, FortuneResult } from "../omikuji";
 
 describe("omikuji type guards", () => {
   const omikujiResult: OmikujiResult = {
@@ -26,6 +26,22 @@ describe("omikuji type guards", () => {
         fail("Expected omikuji result");
       }
     });
+  });
+
+  describe("isFortuneLevel", () => {
+    it.each(["daikichi", "chukichi", "shokichi", "kichi", "suekichi", "kyo", "daikyo"])(
+      "returns true for known level %s",
+      (level) => {
+        expect(isFortuneLevel(level)).toBe(true);
+      }
+    );
+
+    it.each([null, undefined, 0, "", "super-kichi", "Daikichi", {}])(
+      "returns false for invalid input %p",
+      (value) => {
+        expect(isFortuneLevel(value)).toBe(false);
+      }
+    );
   });
 
   describe("OmikujiResult", () => {

--- a/types/omikuji.ts
+++ b/types/omikuji.ts
@@ -25,6 +25,23 @@ export type FortuneLevel =
   | "kyo"
   | "daikyo";
 
+const FORTUNE_LEVELS: readonly FortuneLevel[] = [
+  "daikichi",
+  "chukichi",
+  "shokichi",
+  "kichi",
+  "suekichi",
+  "kyo",
+  "daikyo",
+];
+
+/**
+ * 型ガード: 値が FortuneLevel union のいずれかであるかを判定する。
+ */
+export function isFortuneLevel(value: unknown): value is FortuneLevel {
+  return typeof value === "string" && (FORTUNE_LEVELS as readonly string[]).includes(value);
+}
+
 /**
  * おみくじの結果。
  * BaseFortune を拡張し、おみくじ固有のフィールドを持つ。

--- a/utils/HistoryStorage.ts
+++ b/utils/HistoryStorage.ts
@@ -1,7 +1,11 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import type { ImageSourcePropType } from "react-native";
-import { FortuneResult, OmikujiResult, isFortuneLevel } from "../types/omikuji";
+import { FortuneResult } from "../types/omikuji";
+import { migrateLegacyEntry, getTodayString } from "../domain";
 import { captureException } from "./sentry";
+
+// Re-exported for backward compatibility; external callers now prefer the
+// `domain/` import path.
+export { getTodayString };
 
 /**
  * HistoryStorage 内部のエラーを Sentry に送信し、ログに記録する。
@@ -24,55 +28,6 @@ const MAX_HISTORY_ITEMS = 50;
  * 現状はおみくじのみだが、将来は他の占い種別（タロット等）も受け入れる。
  */
 export type HistoryEntry = FortuneResult;
-
-/**
- * レガシー履歴データ（type フィールドがない古いデータ）を
- * 新しい BaseFortune 形式にマイグレートする。
- *
- * 壊れた / 未知形式のペイロードは `null` を返し、呼び出し元で除外される。
- * 以前は `as Partial<OmikujiResult>` で素通ししていたが、各フィールドを型
- * ガードで検証してから明示的に OmikujiResult を組み立てる。
- */
-function migrateLegacyEntry(raw: unknown): HistoryEntry | null {
-  if (typeof raw !== "object" || raw === null) return null;
-  const r = raw as Record<string, unknown>;
-
-  // type は存在する場合のみ "omikuji" を許可（将来の占い種別は未対応）
-  if (r.type !== undefined && r.type !== "omikuji") return null;
-
-  if (typeof r.id !== "string" || r.id.length === 0) return null;
-  if (!isFortuneLevel(r.level)) return null;
-  if (typeof r.messageIndex !== "number" || !Number.isFinite(r.messageIndex)) return null;
-  if (typeof r.color !== "string") return null;
-  if (typeof r.createdAt !== "number" || !Number.isFinite(r.createdAt)) return null;
-  if (r.image == null) return null;
-
-  const result: OmikujiResult = {
-    id: r.id,
-    type: "omikuji",
-    level: r.level,
-    messageIndex: r.messageIndex,
-    // ImageSourcePropType は number | { uri: string } | array 等の union。
-    // 構造的検証は non-null のみ（各形式は RN 側 Image コンポーネントが扱う）
-    image: r.image as ImageSourcePropType,
-    color: r.color,
-    createdAt: r.createdAt,
-  };
-  return result;
-}
-
-/**
- * 今日の日付を YYYY-MM-DD 形式で返す。
- *
- * この値は「1 日 1 回制限」の判定基準として使用される。
- * デバイスのローカルタイムゾーンに依存する設計である点に注意:
- * タイムゾーン変更・国境越えユーザーの挙動、将来 UTC 切替する場合の方針は
- * `docs/guides/TIMEZONE_POLICY.md` を参照。
- */
-export function getTodayString(): string {
-  const now = new Date();
-  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
-}
 
 /**
  * 履歴を取得する

--- a/utils/HistoryStorage.ts
+++ b/utils/HistoryStorage.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { FortuneResult, OmikujiResult } from "../types/omikuji";
+import type { ImageSourcePropType } from "react-native";
+import { FortuneResult, OmikujiResult, isFortuneLevel } from "../types/omikuji";
 import { captureException } from "./sentry";
 
 /**
@@ -27,15 +28,37 @@ export type HistoryEntry = FortuneResult;
 /**
  * レガシー履歴データ（type フィールドがない古いデータ）を
  * 新しい BaseFortune 形式にマイグレートする。
+ *
+ * 壊れた / 未知形式のペイロードは `null` を返し、呼び出し元で除外される。
+ * 以前は `as Partial<OmikujiResult>` で素通ししていたが、各フィールドを型
+ * ガードで検証してから明示的に OmikujiResult を組み立てる。
  */
 function migrateLegacyEntry(raw: unknown): HistoryEntry | null {
   if (typeof raw !== "object" || raw === null) return null;
-  const entry = raw as Partial<OmikujiResult> & { type?: string };
-  if (!entry.id || !entry.level || typeof entry.createdAt !== "number") return null;
-  return {
-    ...entry,
-    type: entry.type === "omikuji" ? "omikuji" : "omikuji",
-  } as OmikujiResult;
+  const r = raw as Record<string, unknown>;
+
+  // type は存在する場合のみ "omikuji" を許可（将来の占い種別は未対応）
+  if (r.type !== undefined && r.type !== "omikuji") return null;
+
+  if (typeof r.id !== "string" || r.id.length === 0) return null;
+  if (!isFortuneLevel(r.level)) return null;
+  if (typeof r.messageIndex !== "number" || !Number.isFinite(r.messageIndex)) return null;
+  if (typeof r.color !== "string") return null;
+  if (typeof r.createdAt !== "number" || !Number.isFinite(r.createdAt)) return null;
+  if (r.image == null) return null;
+
+  const result: OmikujiResult = {
+    id: r.id,
+    type: "omikuji",
+    level: r.level,
+    messageIndex: r.messageIndex,
+    // ImageSourcePropType は number | { uri: string } | array 等の union。
+    // 構造的検証は non-null のみ（各形式は RN 側 Image コンポーネントが扱う）
+    image: r.image as ImageSourcePropType,
+    color: r.color,
+    createdAt: r.createdAt,
+  };
+  return result;
 }
 
 /**

--- a/utils/__tests__/HistoryStorage.test.ts
+++ b/utils/__tests__/HistoryStorage.test.ts
@@ -115,6 +115,73 @@ describe("HistoryStorage", () => {
     expect(savedData[49].id).toBe("existing-48");
   });
 
+  it("drops entries whose payload fails shape validation", async () => {
+    // Corrupted mix: unknown level, non-numeric messageIndex, missing image,
+    // and one valid legacy entry that should survive.
+    const mixedPayload = [
+      {
+        id: "bad-1",
+        level: "not-a-level",
+        messageIndex: 0,
+        image: { uri: "x" },
+        color: "#000",
+        createdAt: 1,
+      },
+      {
+        id: "bad-2",
+        level: "daikichi",
+        messageIndex: "zero",
+        image: { uri: "x" },
+        color: "#000",
+        createdAt: 1,
+      },
+      { id: "bad-3", level: "daikichi", messageIndex: 0, color: "#000", createdAt: 1 }, // no image
+      { id: "bad-4", level: "daikichi", messageIndex: 0, image: { uri: "x" }, color: "#000" }, // no createdAt
+      {
+        id: "",
+        level: "daikichi",
+        messageIndex: 0,
+        image: { uri: "x" },
+        color: "#000",
+        createdAt: 1,
+      }, // empty id
+      {
+        id: "good",
+        level: "daikichi",
+        messageIndex: 0,
+        image: { uri: "x" },
+        color: "#000",
+        createdAt: 123,
+      },
+    ];
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(mixedPayload));
+
+    const result = await getHistory();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("good");
+    expect(result[0].type).toBe("omikuji");
+  });
+
+  it("rejects entries with unknown fortune type", async () => {
+    const payload = [
+      {
+        id: "tarot-1",
+        type: "tarot",
+        level: "daikichi",
+        messageIndex: 0,
+        image: { uri: "x" },
+        color: "#000",
+        createdAt: 1,
+      },
+    ];
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(payload));
+
+    const result = await getHistory();
+
+    expect(result).toEqual([]);
+  });
+
   it("manages last draw date", async () => {
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
     expect(await getLastDrawDate()).toBeNull();

--- a/utils/buildShareText.ts
+++ b/utils/buildShareText.ts
@@ -1,28 +1,5 @@
-const APP_URL = "https://digital-omikuji.vercel.app";
-const HASHTAGS = ["#エンジニアおみくじ2026", "#令和八年"];
-
-interface ShareTextParams {
-  title: string;
-  description: string;
-}
-
 /**
- * Builds the share text for X (Twitter).
- *
- * Template:
- * 2026年のエンジニア運勢は
- * 『{運勢}』
- * {description}
- *
- * #エンジニアおみくじ2026
- * #令和八年
- *
- * あなたも占ってみよう👇
- * {URL}
+ * @deprecated 本モジュールは後方互換のための薄い再エクスポート。
+ * 新規コードは `domain/buildShareText` から直接 import すること。
  */
-export function buildShareText(params: ShareTextParams): string {
-  const hashtags = HASHTAGS.join("\n");
-  const url = `${APP_URL}?utm_source=share&utm_campaign=omikuji2026`;
-
-  return `2026年のエンジニア運勢は\n『${params.title}』\n${params.description}\n\n${hashtags}\n\nあなたも占ってみよう👇\n${url}`;
-}
+export { buildShareText } from "../domain/buildShareText";

--- a/utils/getFortuneText.ts
+++ b/utils/getFortuneText.ts
@@ -1,16 +1,5 @@
-import { TFunction } from "i18next";
-import { FortuneLevel } from "../types/omikuji";
-
-export function getFortuneText(
-  t: TFunction,
-  level: FortuneLevel,
-  messageIndex: number
-): { title: string; message: string } {
-  const title = t(`fortune.levels.${level}`);
-  const messages = t(`fortune.messages.${level}`, { returnObjects: true });
-  const message = Array.isArray(messages)
-    ? messages[messageIndex] || messages[0]
-    : String(messages);
-
-  return { title, message };
-}
+/**
+ * @deprecated 本モジュールは後方互換のための薄い再エクスポート。
+ * 新規コードは `domain/getFortuneText` から直接 import すること。
+ */
+export { getFortuneText } from "../domain/getFortuneText";

--- a/utils/omikujiLogic.ts
+++ b/utils/omikujiLogic.ts
@@ -1,42 +1,6 @@
-import * as Crypto from "expo-crypto";
-import { ACQUIRED_FORTUNES } from "../data/omikujiData";
-import { OmikujiResult } from "../types/omikuji";
-
-// Number of messages per fortune level (matches translation files)
-const MESSAGES_PER_LEVEL = 5;
-
 /**
- * Perform a weighted lottery to select a fortune result.
+ * @deprecated 本モジュールは後方互換のための薄い再エクスポート。
+ * 新規コードは `domain/drawOmikuji` から直接 import すること。
  */
-export const drawOmikuji = (): OmikujiResult => {
-  // 1. Calculate total weight
-  const totalWeight = ACQUIRED_FORTUNES.reduce((sum, item) => sum + item.weight, 0);
-
-  // 2. Random value between 0 and totalWeight
-  let randomValue = Math.random() * totalWeight;
-
-  // 3. Select Fortune Level
-  let selectedData = ACQUIRED_FORTUNES[ACQUIRED_FORTUNES.length - 1]; // Default fallback
-
-  for (const data of ACQUIRED_FORTUNES) {
-    if (randomValue < data.weight) {
-      selectedData = data;
-      break;
-    }
-    randomValue -= data.weight;
-  }
-
-  // 4. Select Random Message Index
-  const messageIndex = Math.floor(Math.random() * MESSAGES_PER_LEVEL);
-
-  // 5. Construct Result
-  return {
-    id: Crypto.randomUUID(),
-    type: "omikuji",
-    level: selectedData.level,
-    messageIndex,
-    image: selectedData.image,
-    color: selectedData.color,
-    createdAt: Date.now(),
-  };
-};
+export { drawOmikuji } from "../domain/drawOmikuji";
+export type { DrawOmikujiOptions } from "../domain/drawOmikuji";


### PR DESCRIPTION
## 目的

おみくじ抽選・運勢判定・共有テキスト生成・履歴マイグレーションなどの**純粋ロジック**を、React / Expo / AsyncStorage / Sentry といった UI・プラットフォーム層から切り離す。

- テスタビリティ向上（RNG / Clock / ID 生成を注入可能に）
- 将来のプラットフォーム（Web 専用ビルドなど）移植時の再利用性確保
- UI 層のリファクタ時に純粋ロジックを壊すリスクを削減

## 変更点

### 新設: `domain/`

| ファイル | 責務 | 公開 API |
|---|---|---|
| `drawOmikuji.ts` | 加重ロット抽選 | `drawOmikuji(options?)` — RNG / Clock / ID 生成を注入可能 |
| `fortuneRules.ts` | 日付判定と 1 日 1 回制限 | `getTodayString(now?)`, `canDrawToday(lastDate, today?)` |
| `getFortuneText.ts` | i18n 経由の運勢文言 | `getFortuneText(t, level, messageIndex)` |
| `buildShareText.ts` | X 共有文生成 | `buildShareText({title, description})` |
| `historyMigration.ts` | レガシー履歴の型ガード移行 | `migrateLegacyEntry(raw)` |
| `index.ts` | 公開境界 | 上記のみ再 export |

### 互換レイヤー: `utils/`

- `utils/omikujiLogic.ts` / `buildShareText.ts` / `getFortuneText.ts` を `domain/` への再エクスポートに縮約（`@deprecated` JSDoc 付き）
- `utils/HistoryStorage.ts` は AsyncStorage 副作用ラッパーに専念し、`getTodayString` / `migrateLegacyEntry` を domain から import。`getTodayString` は後方互換のため再 export

### 境界保証

- `eslint.config.js`: `domain/**` に対して react / react-native / expo / @sentry / @react-native-async-storage の実行時 import を `no-restricted-imports` で禁止（`allowTypeImports: true` により型のみ import は許可）
- `jest.config.js`: `domain/**/*.{ts,tsx}` を `collectCoverageFrom` に追加

## テスト結果

ローカルで以下すべて green:

- `pnpm lint`: 無警告
- `pnpm tsc --noEmit`: 型エラーなし
- `pnpm test -- --coverage`: 43 suites / **283 tests passed**
  - `domain/` カバレッジ: **Stmts 98.03% / Branch 95.91% / Funcs 100% / Lines 97.56%**

## 影響範囲

呼び出し元（`hooks/useOmikujiLogic.ts`, `components/patterns/ResultPattern.tsx`, `HistoryListPattern.tsx`, `app/history.tsx`）は `utils/` 経由のまま変更なし。**API シグネチャ・挙動の破壊的変更なし**。

UI 変更なしのため、スクリーンショット添付は省略。

## セルフレビュー結果（NG / 要確認のみ）

- **要確認**: `domain/fortuneRules.ts` の `canDrawToday` は現状呼び出し元なし。`useOmikujiLogic` の `lastDate === getTodayString()` を置換するフォローアップ PR を予定
- 機械検証ログ: lint ✅ / tsc ✅ / test (with coverage) ✅

## フォローアップ（別 PR）

1. `useOmikujiLogic` / `ResultPattern` / `HistoryListPattern` / `app/history.tsx` の import を `utils/` → `domain/` へ段階移行
2. `useOmikujiLogic` を `canDrawToday` ベースに差し替え
3. `utils/__tests__/omikujiLogic.test.ts` / `buildShareText.test.ts` と domain 側の重複テストを整理
4. `@deprecated` 再エクスポート層の廃止期限を CHANGELOG で宣言