### PR TITLE
[refactor] 呼び出し元 import を domain へ移行 + canDrawToday 適用

### DIFF
--- a/components/patterns/HistoryListPattern.tsx
+++ b/components/patterns/HistoryListPattern.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { FlatList, View } from "react-native";
 import { useTranslation } from "react-i18next";
 import { HistoryEntry } from "../../utils/HistoryStorage";
-import { getFortuneText } from "../../utils/getFortuneText";
+import { getFortuneText } from "../../domain";
 import { HistoryEmptyState } from "../design-system/HistoryEmptyState";
 import { HistoryItemCard } from "../design-system/HistoryItemCard";
 

--- a/components/patterns/ResultPattern.tsx
+++ b/components/patterns/ResultPattern.tsx
@@ -2,8 +2,7 @@ import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { OmikujiResult } from "../../types/omikuji";
 import { DETAIL_KEYS } from "../../data/omikujiData";
-import { buildShareText } from "../../utils/buildShareText";
-import { getFortuneText } from "../../utils/getFortuneText";
+import { buildShareText, getFortuneText } from "../../domain";
 import { FortuneDetailEntry, PaperResultCard } from "../design-system/PaperResultCard";
 
 interface ResultPatternProps {

--- a/hooks/useOmikujiLogic.ts
+++ b/hooks/useOmikujiLogic.ts
@@ -1,11 +1,10 @@
 import { useState, useCallback, useEffect } from "react";
 import { OmikujiResult } from "../types/omikuji";
-import { drawOmikuji } from "../utils/omikujiLogic";
+import { canDrawToday, drawOmikuji } from "../domain";
 import {
   addHistoryEntry,
   getHistory,
   getLastDrawDate,
-  getTodayString,
   clearHistory,
   HistoryEntry,
 } from "../utils/HistoryStorage";
@@ -26,7 +25,7 @@ export const useOmikujiLogic = () => {
       const [historyData, lastDate] = await Promise.all([getHistory(), getLastDrawDate()]);
       setHistory(historyData);
 
-      if (lastDate === getTodayString() && historyData.length > 0) {
+      if (!canDrawToday(lastDate) && historyData.length > 0) {
         setHasDrawnToday(true);
         setFortune(historyData[0]);
       }


### PR DESCRIPTION
## 目的

PR #362 で新設した `domain/` 層を呼び出し元から直接利用するよう切り替え、`utils/` shim への依存を減らす。併せて #362 で未使用だった `canDrawToday` を実地で利用し、純粋ロジックの境界価値を確立する。

> ℹ️ このPRは #363 の再提出です。#362 のマージに伴いベースブランチが削除され #363 は自動 closed となったため、develop base で作り直しました。内容は同一です。

## 変更点

| ファイル | 変更 |
|---|---|
| `hooks/useOmikujiLogic.ts` | `drawOmikuji` / `canDrawToday` を `../domain` から import。`lastDate === getTodayString()` の比較を `!canDrawToday(lastDate)` に置き換え |
| `components/patterns/ResultPattern.tsx` | `buildShareText` / `getFortuneText` を `../../domain` から import |
| `components/patterns/HistoryListPattern.tsx` | `getFortuneText` を `../../domain` から import (`HistoryEntry` 型は副作用を含む `utils/HistoryStorage` のまま) |

`app/history.tsx` は副作用系 API (`clearHistory` / `getHistory`) のみ利用しているため本 PR では変更なし。

## 挙動変更の有無

なし。`canDrawToday(lastDate)` と `lastDate === getTodayString()` はタイムゾーン規約が同一 (ローカルタイム、`getTodayString` 経由) のため等価。

## テスト結果

- `pnpm lint`: ✅ 無警告
- `pnpm tsc --noEmit`: ✅ 型エラーなし
- `pnpm test`: ✅ 43 suites / **286 tests passed**

## 影響範囲

UI 変更なし。hooks の内部実装のみ差し替え。スクリーンショット添付省略。

## フォローアップ

- `utils/__tests__/omikujiLogic.test.ts` / `buildShareText.test.ts` の重複テスト整理（別 PR: #364 継承予定）
- `utils/omikujiLogic.ts` / `utils/buildShareText.ts` / `utils/getFortuneText.ts` の @deprecated shim 削除（呼び出し元ゼロを grep で確認済、別 PR）