### PR TITLE
[refactor] @deprecated な utils shim 3 ファイルを削除

### DIFF
--- a/utils/buildShareText.ts
+++ b/utils/buildShareText.ts
@@ -1,5 +1,0 @@
-/**
- * @deprecated 本モジュールは後方互換のための薄い再エクスポート。
- * 新規コードは `domain/buildShareText` から直接 import すること。
- */
-export { buildShareText } from "../domain/buildShareText";

--- a/utils/getFortuneText.ts
+++ b/utils/getFortuneText.ts
@@ -1,5 +1,0 @@
-/**
- * @deprecated 本モジュールは後方互換のための薄い再エクスポート。
- * 新規コードは `domain/getFortuneText` から直接 import すること。
- */
-export { getFortuneText } from "../domain/getFortuneText";

--- a/utils/omikujiLogic.ts
+++ b/utils/omikujiLogic.ts
@@ -1,6 +1,0 @@
-/**
- * @deprecated 本モジュールは後方互換のための薄い再エクスポート。
- * 新規コードは `domain/drawOmikuji` から直接 import すること。
- */
-export { drawOmikuji } from "../domain/drawOmikuji";
-export type { DrawOmikujiOptions } from "../domain/drawOmikuji";


### PR DESCRIPTION
## 目的

domain 層への移行 (#362, #365, #366) が完了し、`utils/` 配下の再エクスポート shim (`@deprecated`) は呼び出し元ゼロとなった。猶予期間を設けていたが、現状で参照が残っていないため削除して技術的負債を清算する。

## 変更点

- `utils/omikujiLogic.ts` を削除 (`drawOmikuji` の再 export shim)
- `utils/buildShareText.ts` を削除 (`buildShareText` の再 export shim)
- `utils/getFortuneText.ts` を削除 (`getFortuneText` の再 export shim)

`utils/HistoryStorage.ts` は AsyncStorage 副作用ラッパーとして残り、本 PR では変更しない。

## セルフレビュー

SELF_REVIEW_CHECKLIST.md §2.2「残骸ゼロ」に基づき、shim の参照を `rg "utils/(omikujiLogic|buildShareText|getFortuneText)"` で確認:

```
docs/archive/phase1_roadmap.md:111:- [x] `utils/buildShareText.ts` の作成
```

コード上の参照はゼロ。archive docs は履歴保全目的のため変更対象外。

## テスト結果

- `pnpm lint`: ✅ 無警告
- `pnpm tsc --noEmit`: ✅ 型エラーなし
- `pnpm test`: ✅ **41 suites / 281 tests passed** (挙動変更なし)

## 影響範囲

削除のみ。import パスが `utils/` → `domain/` に統一された結果、境界が明確化される。