### PR TITLE
[refactor] canDrawToday に today を明示注入し utils re-export を削除

### DIFF
--- a/hooks/useOmikujiLogic.ts
+++ b/hooks/useOmikujiLogic.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from "react";
 import { OmikujiResult } from "../types/omikuji";
-import { canDrawToday, drawOmikuji } from "../domain";
+import { canDrawToday, drawOmikuji, getTodayString } from "../domain";
 import {
   addHistoryEntry,
   getHistory,
@@ -25,7 +25,7 @@ export const useOmikujiLogic = () => {
       const [historyData, lastDate] = await Promise.all([getHistory(), getLastDrawDate()]);
       setHistory(historyData);
 
-      if (!canDrawToday(lastDate) && historyData.length > 0) {
+      if (!canDrawToday(lastDate, getTodayString()) && historyData.length > 0) {
         setHasDrawnToday(true);
         setFortune(historyData[0]);
       }

--- a/utils/HistoryStorage.ts
+++ b/utils/HistoryStorage.ts
@@ -3,10 +3,6 @@ import { FortuneResult } from "../types/omikuji";
 import { migrateLegacyEntry, getTodayString } from "../domain";
 import { captureException } from "./sentry";
 
-// Re-exported for backward compatibility; external callers now prefer the
-// `domain/` import path.
-export { getTodayString };
-
 /**
  * HistoryStorage 内部のエラーを Sentry に送信し、ログに記録する。
  * ユーザー通知は行わない（silent error）。フォールバック値は呼び出し元で返す。


### PR DESCRIPTION
## 目的

PR #365 の Gemini レビュー指摘（medium）に対応。domain 層の不変条件「時刻などの非決定性は引数で注入する」(`domain/index.ts`) を呼び出し元でも厳密に守るよう更新し、併せて未使用となっていた `utils/HistoryStorage.ts` の `getTodayString` re-export を削除する。

## 変更点

| ファイル | 変更 |
|---|---|
| `hooks/useOmikujiLogic.ts` | `canDrawToday(lastDate)` → `canDrawToday(lastDate, getTodayString())` に変更。`getTodayString` を `../domain` から import |
| `utils/HistoryStorage.ts` | 外部未使用の `export { getTodayString };` を削除。内部の `setLastDrawDate(getTodayString())` は domain 直接 import で動作継続 |

`canDrawToday` の第 2 引数は optional のまま（後方互換）で、production path では必ず明示注入されるため domain は純粋保持。テスト・A/B 実験では任意の `today` を渡せる。

## 挙動変更の有無

なし。`canDrawToday(lastDate, getTodayString())` と `canDrawToday(lastDate)` はタイムゾーン規約が同一のため等価。

## テスト結果

- `pnpm lint`: ✅ 無警告
- `pnpm tsc --noEmit`: ✅ 型エラーなし
- `pnpm test`: ✅ **41 suites / 281 tests passed**

## セルフレビュー

- SELF_REVIEW_CHECKLIST.md §2.2「残骸ゼロ」: 未使用 re-export を削除
- 同 §2.3「境界」: hooks が time source を明示して domain に注入する形になり、時刻依存の境界が明確化

## 影響範囲

hooks 内部実装と utils の API（未使用の re-export 削除）のみ。UI 変更なし。