### PR TITLE
[feat] 設定画面: シェイク無効化とモーション軽減 (closes #180)

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -6,6 +6,7 @@ import { router } from "expo-router";
 import { useOmikujiLogic } from "../hooks/useOmikujiLogic";
 import { useReducedMotion } from "../hooks/useReducedMotion";
 import { useShakeDetection } from "../hooks/useShakeDetection";
+import { useAppSettings } from "../hooks/useAppSettings";
 import { useSoundEffects } from "../hooks/useSoundEffects";
 import { useAppStateMachine } from "../hooks/useAppStateMachine";
 import { COMPACT_HEIGHT_BREAKPOINT } from "../constants/layout";
@@ -27,7 +28,9 @@ export default function OmikujiApp() {
   const { t } = useTranslation();
   const { height: viewportHeight } = useWindowDimensions();
   const { fortune, drawFortune, resetFortune, hasDrawnToday } = useOmikujiLogic();
-  const reducedMotion = useReducedMotion();
+  const osReducedMotion = useReducedMotion();
+  const { settings: appSettings } = useAppSettings();
+  const reducedMotion = osReducedMotion || appSettings.forceReducedMotion;
   const { isMuted, toggleMute, playSound } = useSoundEffects();
 
   const { appState, handleShakeStart, handleResultView, handleReset } = useAppStateMachine({
@@ -45,7 +48,7 @@ export default function OmikujiApp() {
   const isCompactLayout = viewportHeight < COMPACT_HEIGHT_BREAKPOINT;
 
   useShakeDetection({
-    enabled: appState === "IDLE" && !hasDrawnToday,
+    enabled: appState === "IDLE" && !hasDrawnToday && appSettings.shakeEnabled,
     threshold: SHAKE_THRESHOLD,
     onShake: handleShakeStart,
   });
@@ -60,13 +63,22 @@ export default function OmikujiApp() {
   );
 
   const historyAction = (
-    <Button
-      label="履歴"
-      onPress={() => router.push("/history")}
-      variant="secondaryQuiet"
-      accessibilityLabel="履歴を見る"
-      accessibilityHint="これまでに引いたおみくじの履歴を表示します"
-    />
+    <View style={{ flexDirection: "row", gap: 8 }}>
+      <Button
+        label="履歴"
+        onPress={() => router.push("/history")}
+        variant="secondaryQuiet"
+        accessibilityLabel="履歴を見る"
+        accessibilityHint="これまでに引いたおみくじの履歴を表示します"
+      />
+      <Button
+        label={t("settings.openButton")}
+        onPress={() => router.push("/settings")}
+        variant="secondaryQuiet"
+        accessibilityLabel={t("settings.openButton")}
+        accessibilityHint="アプリの設定画面を開きます"
+      />
+    </View>
   );
 
   const debugAction = showDebug ? (

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,0 +1,112 @@
+import React, { useCallback } from "react";
+import { ScrollView, Switch, Text, View } from "react-native";
+import { router } from "expo-router";
+import { useTranslation } from "react-i18next";
+import { useAppSettings } from "../hooks/useAppSettings";
+import { navigateBackOrReplace } from "../utils/navigation";
+import { VersionDisplay } from "../components/VersionDisplay";
+import { HistoryScreenTemplate } from "../components/templates/HistoryScreenTemplate";
+import { PageHeader } from "../components/design-system/PageHeader";
+import { Button } from "../components/design-system/Button";
+
+export default function SettingsScreen() {
+  const { t } = useTranslation();
+  const { settings, update, hydrated } = useAppSettings();
+
+  const handleBack = useCallback(() => {
+    navigateBackOrReplace(router);
+  }, []);
+
+  const header = (
+    <PageHeader
+      title={t("settings.title")}
+      subtitle={t("settings.subtitle")}
+      tone="experience"
+      actionPlacement="stacked"
+      leadingAction={<Button label={t("common.back")} onPress={handleBack} variant="textLink" />}
+    />
+  );
+
+  const content = (
+    <ScrollView contentContainerStyle={{ paddingVertical: 8, gap: 16 }}>
+      <SettingRow
+        label={t("settings.shake.label")}
+        description={t("settings.shake.description")}
+        value={settings.shakeEnabled}
+        disabled={!hydrated}
+        onChange={(next) => {
+          void update({ shakeEnabled: next });
+        }}
+      />
+      <SettingRow
+        label={t("settings.reducedMotion.label")}
+        description={t("settings.reducedMotion.description")}
+        value={settings.forceReducedMotion}
+        disabled={!hydrated}
+        onChange={(next) => {
+          void update({ forceReducedMotion: next });
+        }}
+      />
+    </ScrollView>
+  );
+
+  return <HistoryScreenTemplate header={header} content={content} footer={<VersionDisplay />} />;
+}
+
+interface SettingRowProps {
+  label: string;
+  description: string;
+  value: boolean;
+  disabled?: boolean;
+  onChange: (next: boolean) => void;
+}
+
+function SettingRow({ label, description, value, disabled, onChange }: SettingRowProps) {
+  return (
+    <View
+      style={{
+        backgroundColor: "rgba(255,255,255,0.06)",
+        borderRadius: 16,
+        borderWidth: 1,
+        borderColor: "rgba(255,255,255,0.12)",
+        padding: 16,
+      }}
+    >
+      <View
+        style={{
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 12,
+        }}
+      >
+        <Text
+          style={{
+            color: "white",
+            fontSize: 16,
+            fontWeight: "600",
+            flexShrink: 1,
+          }}
+        >
+          {label}
+        </Text>
+        <Switch
+          value={value}
+          disabled={disabled}
+          onValueChange={onChange}
+          accessibilityLabel={label}
+        />
+      </View>
+      <Text
+        style={{
+          color: "rgba(255,255,255,0.74)",
+          fontSize: 13,
+          lineHeight: 20,
+          marginTop: 8,
+        }}
+      >
+        {description}
+      </Text>
+    </View>
+  );
+}

--- a/hooks/useAppSettings.ts
+++ b/hooks/useAppSettings.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  AppSettings,
+  DEFAULT_APP_SETTINGS,
+  getAppSettings,
+  setAppSettings,
+} from "../utils/AppSettingsStorage";
+
+/**
+ * アプリ設定の取得・更新を担う React フック。
+ *
+ * - 初回マウントで AsyncStorage から読み込み、以降は state を真とする
+ * - `update` は楽観的に state を更新したあと永続化する（失敗時の回復は
+ *   行わない＝設定は失っても致命的でないため）
+ */
+export function useAppSettings() {
+  const [settings, setSettings] = useState<AppSettings>(DEFAULT_APP_SETTINGS);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getAppSettings().then((loaded) => {
+      if (cancelled) return;
+      setSettings(loaded);
+      setHydrated(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const update = useCallback(
+    async (patch: Partial<AppSettings>) => {
+      const next = { ...settings, ...patch };
+      setSettings(next);
+      await setAppSettings(next);
+    },
+    [settings]
+  );
+
+  return { settings, update, hydrated };
+}

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -172,5 +172,18 @@
     "deleteConfirmTitle": "Delete History",
     "deleteConfirmMessage": "Are you sure you want to delete all history?",
     "empty": "No history yet.\nTry drawing an Omikuji!"
+  },
+  "settings": {
+    "title": "Settings",
+    "subtitle": "Tune how you interact with and see the experience.",
+    "openButton": "Settings",
+    "shake": {
+      "label": "Draw by shake",
+      "description": "When off, an Omikuji is drawn only by tapping the on-screen button."
+    },
+    "reducedMotion": {
+      "label": "Reduce motion",
+      "description": "Simplifies animations. If your OS \"Reduce Motion\" setting is enabled, motion is reduced regardless of this toggle."
+    }
   }
 }

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -172,5 +172,18 @@
     "deleteConfirmTitle": "履歴を削除",
     "deleteConfirmMessage": "本当にすべての履歴を削除しますか？",
     "empty": "まだ履歴がありません。\nおみくじを引いてみましょう！"
+  },
+  "settings": {
+    "title": "設定",
+    "subtitle": "操作と表示の感じ方を、自分に合わせて整えられます",
+    "openButton": "設定",
+    "shake": {
+      "label": "シェイクで引く",
+      "description": "オフにすると、画面のボタンをタップしたときだけおみくじを引きます"
+    },
+    "reducedMotion": {
+      "label": "アニメーションを抑える",
+      "description": "演出を簡略化します。OS の「視差効果を減らす」設定がオンの場合は、この設定に関わらず簡略化されます"
+    }
   }
 }

--- a/utils/AppSettingsStorage.ts
+++ b/utils/AppSettingsStorage.ts
@@ -1,0 +1,56 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { reportSilentError } from "./errorReporter";
+
+export type AppSettings = {
+  /** false にするとシェイクで抽選しない（タップのみ） */
+  shakeEnabled: boolean;
+  /** true にすると OS 設定に関わらずアニメーションを抑制する */
+  forceReducedMotion: boolean;
+};
+
+export const DEFAULT_APP_SETTINGS: AppSettings = {
+  shakeEnabled: true,
+  forceReducedMotion: false,
+};
+
+const STORAGE_KEY = "app_settings_v1";
+
+function reportSettingsError(operation: string, error: unknown): void {
+  reportSilentError(`[AppSettingsStorage:${operation}]`, error, {
+    source: "AppSettingsStorage",
+    operation,
+  });
+}
+
+function isAppSettings(value: unknown): value is AppSettings {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.shakeEnabled === "boolean" && typeof v.forceReducedMotion === "boolean";
+}
+
+/**
+ * 設定を取得する。未保存・破損時はデフォルトを返す。
+ */
+export async function getAppSettings(): Promise<AppSettings> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (raw == null) return DEFAULT_APP_SETTINGS;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isAppSettings(parsed)) return DEFAULT_APP_SETTINGS;
+    return parsed;
+  } catch (error) {
+    reportSettingsError("getAppSettings", error);
+    return DEFAULT_APP_SETTINGS;
+  }
+}
+
+/**
+ * 設定を保存する。失敗してもユーザー通知は行わない（silent）。
+ */
+export async function setAppSettings(settings: AppSettings): Promise<void> {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  } catch (error) {
+    reportSettingsError("setAppSettings", error);
+  }
+}

--- a/utils/__tests__/AppSettingsStorage.test.ts
+++ b/utils/__tests__/AppSettingsStorage.test.ts
@@ -1,0 +1,53 @@
+import { getAppSettings, setAppSettings, DEFAULT_APP_SETTINGS } from "../AppSettingsStorage";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+const STORAGE_KEY = "app_settings_v1";
+
+describe("AppSettingsStorage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns defaults when storage is empty", async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    const result = await getAppSettings();
+    expect(result).toEqual(DEFAULT_APP_SETTINGS);
+  });
+
+  it("returns defaults when stored payload is malformed JSON", async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue("not json");
+    const result = await getAppSettings();
+    expect(result).toEqual(DEFAULT_APP_SETTINGS);
+  });
+
+  it("returns defaults when payload is missing required fields", async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify({ shakeEnabled: false }));
+    const result = await getAppSettings();
+    expect(result).toEqual(DEFAULT_APP_SETTINGS);
+  });
+
+  it("returns parsed settings when stored payload is valid", async () => {
+    const stored = { shakeEnabled: false, forceReducedMotion: true };
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(stored));
+    const result = await getAppSettings();
+    expect(result).toEqual(stored);
+  });
+
+  it("persists settings via AsyncStorage.setItem", async () => {
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+    const settings = { shakeEnabled: false, forceReducedMotion: true };
+    await setAppSettings(settings);
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(STORAGE_KEY, JSON.stringify(settings));
+  });
+
+  it("swallows AsyncStorage errors silently and returns defaults", async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValue(new Error("disk full"));
+    const result = await getAppSettings();
+    expect(result).toEqual(DEFAULT_APP_SETTINGS);
+  });
+});


### PR DESCRIPTION
## 目的

Issue #180 の受け入れ条件を満たす設定画面を追加する。シェイクが難しいユーザーや演出で酔うユーザー向けに、アプリ内で挙動を調整できるようにする。

Closes #180

## 受け入れ条件

| 条件 | 対応 |
|---|---|
| 「タップで引く」を ON にすると、シェイク不要で抽選できる | `shakeEnabled` トグルで `useShakeDetection` を無効化。既存の「おみくじを引く」ボタンでタップ抽選 |
| OS の reduced motion を尊重し、演出を簡略化できる | 既存 `useReducedMotion` を維持。さらに `forceReducedMotion` トグルで OS 設定に関わらずアプリ側から強制 ON 可能 |
| 既存ユーザーのデフォルト体験は変えない | `DEFAULT_APP_SETTINGS = { shakeEnabled: true, forceReducedMotion: false }` で現挙動を維持 |

## 変更点

### 新規

- `utils/AppSettingsStorage.ts` — AsyncStorage ベースの永続化層
  - キー: `app_settings_v1`
  - 破損 payload は型ガードでフィルタし default 返却
  - silent error で Sentry に送信（既存 `reportSilentError` 流用）
- `utils/__tests__/AppSettingsStorage.test.ts` — 6 ケース（default / 破損 JSON / フィールド欠落 / 正常 / 往復保存 / storage 例外）
- `hooks/useAppSettings.ts` — React state と AsyncStorage を同期
- `app/settings.tsx` — Switch×2 + 説明文の設定画面

### 既存更新

- `app/index.tsx`
  - `useAppSettings()` を取得
  - `useShakeDetection({ enabled: ... && appSettings.shakeEnabled })` を適用
  - `reducedMotion = osReducedMotion || appSettings.forceReducedMotion`
  - header に「設定」遷移ボタンを追加
- `i18n/locales/ja.json` / `en.json` — `settings.*` 配下のキーを追加

## スコープ外

- 計測イベント（`draw_by_tap`, `reduced_motion_enabled`）は Issue #182（計測設計）で扱うため本 PR に含めない

## テスト結果

- `pnpm lint`: ✅
- `pnpm tsc --noEmit`: ✅
- `pnpm test`: ✅ **43 suites / 294 tests passed**（+1 suite / +6 tests）

## 動作確認（推奨）

1. `pnpm web` で起動 → header の「設定」ボタン → 2 つのトグル表示を確認
2. 「シェイクで引く」を OFF → トップ画面に戻り、端末を振っても反応しないことを確認（ボタンタップは動作）
3. 「アニメーションを抑える」を ON → 抽選 → アニメーションが抑制されていることを確認
4. 設定は次回起動時も保持されていることを確認

UI 変更があるため、レビュー時はスクリーンショットで確認してください。