### PR TITLE
[perf] フォントをサブパス import に切替し dist を 25MB 削減

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,11 +2,12 @@
 import { initializeSentry, Sentry } from "../utils/sentry";
 
 import { SplashScreen, Stack } from "expo-router";
-import {
-  useFonts,
-  ShipporiMincho_400Regular,
-  ShipporiMincho_700Bold,
-} from "@expo-google-fonts/shippori-mincho";
+import { useFonts } from "expo-font";
+// バレル import を避け、利用する 2 ウェイトだけサブパス import で取得する。
+// バレル import すると Metro が同パッケージ配下の 500/600/800 等の TTF まで
+// バンドルに含めてしまい、Web 配信物に約 25MB の死荷重が発生する。
+import { ShipporiMincho_400Regular } from "@expo-google-fonts/shippori-mincho/400Regular";
+import { ShipporiMincho_700Bold } from "@expo-google-fonts/shippori-mincho/700Bold";
 import { useEffect } from "react";
 import { logVersionInfo } from "../utils/VersionInfo";
 import "../global.css";


### PR DESCRIPTION
## 目的

複数エージェントによる品質監査で発見された **最大効果の改善** を実装する。`@expo-google-fonts/shippori-mincho` からのバレル import により、利用していない 500/600/800 ウェイトの TTF までバンドルに同梱され、Web 配信物に約 25MB の死荷重が発生していた。

## 変更点

`app/_layout.tsx` のフォント import を以下に変更:

```diff
-import {
-  useFonts,
-  ShipporiMincho_400Regular,
-  ShipporiMincho_700Bold,
-} from "@expo-google-fonts/shippori-mincho";
+import { useFonts } from "expo-font";
+import { ShipporiMincho_400Regular } from "@expo-google-fonts/shippori-mincho/400Regular";
+import { ShipporiMincho_700Bold } from "@expo-google-fonts/shippori-mincho/700Bold";
```

- `useFonts` は `expo-font` から直接 import（公式推奨パターン）
- 各ウェイトはサブパス named import で取得し、Metro が他ウェイトを辿らないようにする
- 将来同じ罠を踏まないようコメントで意図を明記

## 実測結果（pnpm build）

| 項目 | before | after | 差分 |
|---|---|---|---|
| dist 全体 | 45MB | **20MB** | **-25MB / -55%** |
| 同梱 TTF | 5 ウェイト × ~8.2MB | 2 ウェイト × ~8.2MB | -3 ウェイト |

## テスト結果

- `pnpm lint`: ✅
- `pnpm tsc --noEmit`: ✅
- `pnpm test`: ✅ 43 suites / 294 tests passed
- `pnpm build`: ✅ dist 20MB

## 影響範囲

- 表示されるフォントは変化なし（400Regular / 700Bold のみが従来から利用対象）
- ランタイム挙動変更なし
- Web 初回ロードの転送量大幅削減で LCP 改善が見込まれる

## フォローアップ案

監査で挙がった他の P1〜P2 改善:
- B: shareUtils Web 成功パスのテスト追加
- C: drawFortune 二重実行レース防止 + フック spec 追加
- D: SHAKING の a11y live region 追加
- E: AsyncStorage 二重 read/write 解消
- F: Web bundle 削減 (metro alias で moti/reanimated/sentry を Web 用に置換)
- G: セキュリティ P2 (expo-linking 削除、Sentry sendDefaultPii、CSP 等)