### PR TITLE
[test] shareUtils Web 成功パスの単体テストを追加 (監査P1)

### DIFF
--- a/utils/__tests__/shareUtils.test.ts
+++ b/utils/__tests__/shareUtils.test.ts
@@ -1,6 +1,6 @@
 import { Platform, Share } from "react-native";
 import { captureRef } from "react-native-view-shot";
-import { executeShare } from "../shareUtils";
+import { executeShare, internal } from "../shareUtils";
 
 describe("executeShare", () => {
   let consoleErrorSpy: jest.SpyInstance;
@@ -112,6 +112,113 @@ describe("executeShare", () => {
 
       await expect(executeShare({ shareText: "share text" })).resolves.toBeUndefined();
       expect(shareSpy).not.toHaveBeenCalled();
+    });
+
+    describe("web success / fallback paths", () => {
+      const fakeElement = { _: "card" } as unknown as HTMLElement;
+
+      type NavigatorLike = {
+        share?: jest.Mock;
+        canShare?: jest.Mock;
+      };
+      let navigatorMock: NavigatorLike;
+      let clickSpy: jest.Mock;
+      let linkEl: { download: string; href: string; click: jest.Mock };
+
+      let captureSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        captureSpy = jest
+          .spyOn(internal, "captureWebImage")
+          .mockResolvedValue("data:image/png;base64,iVBORw0K");
+
+        clickSpy = jest.fn();
+        linkEl = { download: "", href: "", click: clickSpy };
+
+        globalThis.document = {
+          querySelector: jest.fn().mockReturnValue(fakeElement),
+          createElement: jest.fn().mockReturnValue(linkEl),
+        } as unknown as Document;
+
+        globalThis.fetch = jest.fn().mockResolvedValue({
+          blob: jest.fn().mockResolvedValue(new Blob(["x"], { type: "image/png" })),
+        }) as unknown as typeof fetch;
+
+        // File のフル実装は不要なので最低限の shim を用意する
+        (globalThis as unknown as { File: unknown }).File = class {
+          name: string;
+          type: string;
+          constructor(_parts: unknown[], name: string, opts: { type: string }) {
+            this.name = name;
+            this.type = opts.type;
+          }
+        };
+
+        navigatorMock = {};
+        Object.defineProperty(globalThis, "navigator", {
+          value: navigatorMock,
+          writable: true,
+          configurable: true,
+        });
+      });
+
+      it("calls navigator.share with files when canShare returns true", async () => {
+        navigatorMock.share = jest.fn().mockResolvedValue(undefined);
+        navigatorMock.canShare = jest.fn().mockReturnValue(true);
+
+        await executeShare({ shareText: "text", shareTitle: "title" });
+
+        expect(captureSpy).toHaveBeenCalledWith(fakeElement, undefined);
+        expect(navigatorMock.share).toHaveBeenCalledWith(
+          expect.objectContaining({
+            files: expect.any(Array),
+            title: "title",
+            text: "text",
+          })
+        );
+        expect(clickSpy).not.toHaveBeenCalled();
+      });
+
+      it("falls back to download link when canShare returns false", async () => {
+        navigatorMock.share = jest.fn();
+        navigatorMock.canShare = jest.fn().mockReturnValue(false);
+
+        await executeShare({ shareText: "text" });
+
+        expect(navigatorMock.share).not.toHaveBeenCalled();
+        expect(linkEl.download).toBe("omikuji.png");
+        expect(linkEl.href).toBe("data:image/png;base64,iVBORw0K");
+        expect(clickSpy).toHaveBeenCalledTimes(1);
+      });
+
+      it("falls back to download link when navigator.share is unavailable", async () => {
+        // navigator.share も canShare も未定義なブラウザ相当
+        await executeShare({ shareText: "text" });
+
+        expect(clickSpy).toHaveBeenCalledTimes(1);
+      });
+
+      it("swallows AbortError silently when user cancels the share dialog", async () => {
+        const abortError = new DOMException("cancel", "AbortError");
+        navigatorMock.share = jest.fn().mockRejectedValue(abortError);
+        navigatorMock.canShare = jest.fn().mockReturnValue(true);
+
+        await expect(executeShare({ shareText: "text" })).resolves.toBeUndefined();
+
+        expect(navigatorMock.share).toHaveBeenCalled();
+        // AbortError は正常扱いなので console.error は呼ばれない
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+        expect(clickSpy).not.toHaveBeenCalled();
+      });
+
+      it("logs a warning through reportSilentError when share throws non-Abort error", async () => {
+        navigatorMock.share = jest.fn().mockRejectedValue(new Error("NotAllowed"));
+        navigatorMock.canShare = jest.fn().mockReturnValue(true);
+
+        await executeShare({ shareText: "text" });
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith("Web sharing failed", expect.any(Error));
+      });
     });
   });
 });

--- a/utils/shareUtils.ts
+++ b/utils/shareUtils.ts
@@ -23,6 +23,18 @@ export interface ExecuteShareOptions {
 const DEFAULT_WEB_CARD_SELECTOR = '[data-testid="share-card"], [testID="share-card"]';
 
 /**
+ * テスト容易性のため dynamic import を内部オブジェクトに切り出す。
+ * `jest.spyOn(internal, "captureWebImage")` で差し替え可能にする。
+ * production では `html-to-image` を遅延ロードし Web 初期バンドルに含めない。
+ */
+export const internal = {
+  async captureWebImage(element: HTMLElement, backgroundColor?: string): Promise<string> {
+    const { toPng } = await import("html-to-image");
+    return toPng(element, backgroundColor ? { backgroundColor } : {});
+  },
+};
+
+/**
  * プラットフォーム別にシェア処理を実行する。
  *
  * - **Web**: `html-to-image` で画面をキャプチャし、`navigator.share` または
@@ -88,10 +100,7 @@ async function tryWebShare(
     const element = globalThis.document?.querySelector?.(webCardSelector) as HTMLElement | null;
     if (!element) return false;
 
-    const { toPng } = await import("html-to-image");
-    const dataUrl = await toPng(element, {
-      ...(backgroundColor ? { backgroundColor } : {}),
-    });
+    const dataUrl = await internal.captureWebImage(element, backgroundColor);
 
     const response = await fetch(dataUrl);
     const blob = await response.blob();


### PR DESCRIPTION
## 目的

複数エージェント品質監査の **P1 指摘** に対応。`utils/shareUtils.ts` の Web 共有パスは「element が null」「document が undefined」のみカバーされており、本体の分岐（share 成功 / canShare false / AbortError / その他 Error）が未検証だった。共有はアプリの主要価値のため回帰時の影響が大きい。

## 変更点

### `utils/shareUtils.ts`

`await import("html-to-image")` を `internal.captureWebImage` に切り出し、`jest.spyOn(internal, "captureWebImage")` で差し替え可能にした。production 挙動は不変（引き続き遅延ロードされ Web 初期バンドルに含まれない）。

```diff
+export const internal = {
+  async captureWebImage(element, backgroundColor?) {
+    const { toPng } = await import("html-to-image");
+    return toPng(element, backgroundColor ? { backgroundColor } : {});
+  },
+};

 async function tryWebShare(...) {
-  const { toPng } = await import("html-to-image");
-  const dataUrl = await toPng(element, ...);
+  const dataUrl = await internal.captureWebImage(element, backgroundColor);
 }
```

### `utils/__tests__/shareUtils.test.ts`

web ブロックに 5 ケース追加:
| # | 観点 |
|---|---|
| 1 | `canShare=true` のとき `navigator.share` に files/title/text が渡る |
| 2 | `canShare=false` のとき `<a download>` へフォールバック |
| 3 | `navigator.share` 自体が未定義でも `<a download>` でフォールバック |
| 4 | `AbortError`（ユーザキャンセル）は `console.error` を出さず正常終了 |
| 5 | その他の `Error` は `reportSilentError` 経由で `"Web sharing failed"` を警告ログ |

## テスト結果

- `pnpm lint`: ✅
- `pnpm tsc --noEmit`: ✅
- `pnpm test`: ✅ **43 suites / 299 tests passed**（+5）

## 影響範囲

production ランタイムの挙動変更なし。`utils/shareUtils.ts` のモジュールトポロジーがわずかに変わったため、他の呼び出し元（`PaperResultCard`）は影響なしを確認済。

## 参考 (監査指摘)

test-engineer monitor:
> shareUtils.ts:79–127 の分岐カバレッジは事実上 < 30%。Critical user flow の Web 共有が無検証。