### PR TITLE
[fix] drawFortune 書込みレース防止 + 欠落フック spec 追加 (監査P1)

### DIFF
--- a/hooks/__tests__/useReducedMotion.test.ts
+++ b/hooks/__tests__/useReducedMotion.test.ts
@@ -1,0 +1,64 @@
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+import { AccessibilityInfo } from "react-native";
+import { useReducedMotion } from "../useReducedMotion";
+
+type ReduceMotionListener = (value: boolean) => void;
+
+describe("useReducedMotion", () => {
+  let listeners: ReduceMotionListener[];
+  let removeSpy: jest.Mock;
+
+  beforeEach(() => {
+    listeners = [];
+    removeSpy = jest.fn();
+
+    jest.spyOn(AccessibilityInfo, "isReduceMotionEnabled").mockResolvedValue(false);
+
+    jest
+      .spyOn(AccessibilityInfo, "addEventListener")
+      // RN の addEventListener はイベント名で型が分岐するオーバーロードのため
+      // any でキャストして reduceMotionChanged ハンドラを捕捉する
+      .mockImplementation(((event: string, handler: unknown) => {
+        if (event === "reduceMotionChanged") {
+          listeners.push(handler as ReduceMotionListener);
+        }
+        return { remove: removeSpy };
+      }) as unknown as typeof AccessibilityInfo.addEventListener);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns false initially before the OS value resolves", () => {
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(false);
+  });
+
+  it("reflects the OS value after isReduceMotionEnabled resolves", async () => {
+    (AccessibilityInfo.isReduceMotionEnabled as jest.Mock).mockResolvedValue(true);
+    const { result } = renderHook(() => useReducedMotion());
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it("updates when reduceMotionChanged event fires", async () => {
+    const { result } = renderHook(() => useReducedMotion());
+    await waitFor(() => expect(result.current).toBe(false));
+
+    await act(async () => {
+      listeners.forEach((listener) => listener(true));
+    });
+    expect(result.current).toBe(true);
+
+    await act(async () => {
+      listeners.forEach((listener) => listener(false));
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("removes the event listener on unmount", () => {
+    const { unmount } = renderHook(() => useReducedMotion());
+    unmount();
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hooks/__tests__/useSoundEffects.test.ts
+++ b/hooks/__tests__/useSoundEffects.test.ts
@@ -1,0 +1,78 @@
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+import { soundManager } from "../../utils/SoundManager";
+import { useSoundEffects } from "../useSoundEffects";
+
+describe("useSoundEffects", () => {
+  let initializeSpy: jest.SpyInstance;
+  let loadSoundSpy: jest.SpyInstance;
+  let playSoundSpy: jest.SpyInstance;
+  let setMuteSpy: jest.SpyInstance;
+  let unloadAllSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    initializeSpy = jest.spyOn(soundManager, "initialize").mockResolvedValue(undefined);
+    loadSoundSpy = jest.spyOn(soundManager, "loadSound").mockResolvedValue(null);
+    playSoundSpy = jest.spyOn(soundManager, "playSound").mockResolvedValue(undefined);
+    setMuteSpy = jest.spyOn(soundManager, "setMute").mockResolvedValue(undefined);
+    unloadAllSpy = jest.spyOn(soundManager, "unloadAll").mockResolvedValue(undefined);
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("initializes the sound manager and loads shake/result assets on mount", async () => {
+    renderHook(() => useSoundEffects());
+    await waitFor(() => {
+      expect(initializeSpy).toHaveBeenCalledTimes(1);
+      expect(loadSoundSpy).toHaveBeenCalledTimes(2);
+    });
+    const keys = loadSoundSpy.mock.calls.map((call) => call[0]);
+    expect(keys).toEqual(expect.arrayContaining(["shake", "result"]));
+  });
+
+  it("warns with the sound key when loadSound throws", async () => {
+    loadSoundSpy.mockRejectedValueOnce(new Error("bad asset"));
+    renderHook(() => useSoundEffects());
+    await waitFor(() => expect(warnSpy).toHaveBeenCalled());
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/sound not found/));
+  });
+
+  it("toggles mute state and forwards to soundManager.setMute", async () => {
+    const { result } = renderHook(() => useSoundEffects());
+    await waitFor(() => expect(initializeSpy).toHaveBeenCalled());
+
+    expect(result.current.isMuted).toBe(false);
+
+    act(() => {
+      result.current.toggleMute();
+    });
+    expect(result.current.isMuted).toBe(true);
+    expect(setMuteSpy).toHaveBeenLastCalledWith(true);
+
+    act(() => {
+      result.current.toggleMute();
+    });
+    expect(result.current.isMuted).toBe(false);
+    expect(setMuteSpy).toHaveBeenLastCalledWith(false);
+  });
+
+  it("delegates playSound to soundManager", async () => {
+    const { result } = renderHook(() => useSoundEffects());
+    await waitFor(() => expect(initializeSpy).toHaveBeenCalled());
+
+    act(() => {
+      result.current.playSound("shake");
+    });
+    expect(playSoundSpy).toHaveBeenCalledWith("shake");
+  });
+
+  it("calls unloadAll on unmount", async () => {
+    const { unmount } = renderHook(() => useSoundEffects());
+    await waitFor(() => expect(initializeSpy).toHaveBeenCalled());
+    unmount();
+    expect(unloadAllSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hooks/useOmikujiLogic.ts
+++ b/hooks/useOmikujiLogic.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import Constants from "expo-constants";
 import { OmikujiResult } from "../types/omikuji";
 import { canDrawToday, drawOmikuji, getTodayString } from "../domain";
@@ -14,6 +14,9 @@ export const useOmikujiLogic = () => {
   const [fortune, setFortune] = useState<OmikujiResult | null>(null);
   const [history, setHistory] = useState<HistoryEntry[]>([]);
   const [hasDrawnToday, setHasDrawnToday] = useState(false);
+  // drawFortune の多重起動（状態機械の effect 再実行や連打）で
+  // addHistoryEntry が二重に走るのを防ぐ書込みロック。
+  const writingRef = useRef(false);
 
   const loadHistory = useCallback(async () => {
     const data = await getHistory();
@@ -22,8 +25,10 @@ export const useOmikujiLogic = () => {
   }, []);
 
   useEffect(() => {
+    let cancelled = false;
     async function initialize() {
       const [historyData, lastDate] = await Promise.all([getHistory(), getLastDrawDate()]);
+      if (cancelled) return;
       setHistory(historyData);
 
       if (!canDrawToday(lastDate, getTodayString()) && historyData.length > 0) {
@@ -33,22 +38,33 @@ export const useOmikujiLogic = () => {
     }
 
     initialize();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const drawFortune = useCallback(async () => {
     if (hasDrawnToday) {
       return fortune;
     }
+    if (writingRef.current) {
+      // 既に書込み中：同一セッションでの二重発火を無視する
+      return fortune;
+    }
+    writingRef.current = true;
+    try {
+      const result = drawOmikuji();
 
-    const result = drawOmikuji();
+      setFortune(result);
+      setHasDrawnToday(true);
 
-    setFortune(result);
-    setHasDrawnToday(true);
+      await addHistoryEntry(result);
+      await loadHistory();
 
-    await addHistoryEntry(result);
-    await loadHistory();
-
-    return result;
+      return result;
+    } finally {
+      writingRef.current = false;
+    }
   }, [hasDrawnToday, fortune, loadHistory]);
 
   const resetFortune = useCallback(() => {


### PR DESCRIPTION
## 目的

複数エージェント品質監査の **P1 指摘 2 件** に対応。

1. `useOmikujiLogic.drawFortune` が状態機械の effect 再実行や連打で並列呼出しされると `addHistoryEntry` が二重発火するレース。
2. `useReducedMotion` / `useSoundEffects` の専用テスト不在で、回帰時に「動かない理由が分からない」失敗を生む。

## 変更点

### `hooks/useOmikujiLogic.ts`

- `writingRef` による書込みロックを追加。`drawFortune` は実行中にさらに呼ばれても fortune を即返して no-op
- `initialize()` 側に `cancelled` フラグを追加し、StrictMode double-invoke / unmount 後の `setState` を防止

### `hooks/__tests__/useReducedMotion.test.ts` (新規 / 4 ケース)

- 初期 false
- `isReduceMotionEnabled` resolve 後の true 反映
- `reduceMotionChanged` イベント発火時の更新
- unmount 時の `sub.remove` 呼び出し

### `hooks/__tests__/useSoundEffects.test.ts` (新規 / 5 ケース)

- `initialize` + `loadSound("shake")` + `loadSound("result")` の呼び出し
- `loadSound` 失敗時の `console.warn("... sound not found")`
- `toggleMute` と `setMute` の連携（true → false）
- `playSound` の委譲
- unmount 時の `unloadAll`

## テスト結果

- `pnpm lint`: ✅
- `pnpm tsc --noEmit`: ✅
- `pnpm test`: ✅ **45 suites / 308 tests passed**（+2 suites / +9 tests）

## 影響範囲

`drawFortune` の挙動変更は **防御のみ**。通常の 1 回呼び出しは従来通り動作。二重呼び出し時に「fortune を即返す」という安全側の変更で、テストはすべて pass。