### PR TITLE
[a11y] ShakingPattern に進捗アナウンス用 live region を追加 (監査P1)

### DIFF
--- a/components/patterns/ShakingPattern.tsx
+++ b/components/patterns/ShakingPattern.tsx
@@ -19,6 +19,13 @@ export function ShakingPattern({ reducedMotion = false }: ShakingPatternProps) {
       }}
       transition={{ type: "timing", duration: 90, loop: true }}
       style={{ alignItems: "center" }}
+      // スクリーンリーダー向けの進捗フィードバック。SHAKING 中の数秒間に
+      // 状況が伝わらないと VoiceOver / TalkBack ユーザーが「固まった」と
+      // 誤認するため、progressbar role と live region でアナウンスする。
+      accessible
+      accessibilityRole="progressbar"
+      accessibilityLabel="念を込めてシェイクしています"
+      accessibilityLiveRegion="polite"
     >
       <Text style={{ fontSize: 92 }}>🫨</Text>
       <MotionView

--- a/components/patterns/__tests__/ShakingPattern.test.tsx
+++ b/components/patterns/__tests__/ShakingPattern.test.tsx
@@ -12,4 +12,11 @@ describe("ShakingPattern", () => {
     const { getByText } = render(<ShakingPattern reducedMotion />);
     expect(getByText("念を込めて...")).toBeTruthy();
   });
+
+  it("exposes a polite live region with progress role for screen readers", () => {
+    const { getByRole } = render(<ShakingPattern />);
+    const node = getByRole("progressbar");
+    expect(node.props.accessibilityLabel).toBe("念を込めてシェイクしています");
+    expect(node.props.accessibilityLiveRegion).toBe("polite");
+  });
 });


### PR DESCRIPTION
## 目的

複数エージェント品質監査の **P1 指摘** に対応。SHAKING 状態では DRAWING へ遷移するまで約 1.5 秒の待機があり、スクリーンリーダー利用者に状況が伝わらず「アプリが固まった」と誤認される恐れがあった。

## 変更点

### `components/patterns/ShakingPattern.tsx`

最外層の MotionView に以下の a11y props を追加:

```tsx
accessible
accessibilityRole="progressbar"
accessibilityLabel="念を込めてシェイクしています"
accessibilityLiveRegion="polite"
```

- `accessibilityRole="progressbar"` で「進行中の作業」であることを伝える
- `accessibilityLiveRegion="polite"` で Android TalkBack に割り込まずアナウンス
- `accessibilityLabel` で具体的な状況を説明

視覚・アニメーションの変更はなし。

### `components/patterns/__tests__/ShakingPattern.test.tsx`

`getByRole("progressbar")` で要素を取得し `accessibilityLabel` / `accessibilityLiveRegion` を検証する 1 ケースを追加。

## テスト結果

- `pnpm lint`: ✅
- `pnpm tsc --noEmit`: ✅
- `pnpm test`: ✅ **45 suites / 309 tests passed**（+1）

## 参考 (監査指摘)

frontend-specialist:
> SHAKING 状態には overlayLabel も accessibilityLiveRegion も設定がないため、シェイク中の状況が VoiceOver/TalkBack に伝わらない。状態遷移の中で SHAKING 1.5 秒 + DRAWING 3.5 秒の長い待機中に進捗が読み上げられないと、スクリーンリーダー利用者は「アプリが固まった」と誤認する。