### PR TITLE
[perf] addHistoryEntry で再読込を省略し抽選体験の I/O を削減 (監査P1)

### DIFF
--- a/hooks/useOmikujiLogic.ts
+++ b/hooks/useOmikujiLogic.ts
@@ -58,14 +58,17 @@ export const useOmikujiLogic = () => {
       setFortune(result);
       setHasDrawnToday(true);
 
-      await addHistoryEntry(result);
-      await loadHistory();
+      // 既に state に保持している history を渡すことで AsyncStorage からの
+      // 再読込 (JSON parse + migrate map) を省略する。書込み完了後の
+      // 履歴配列をそのまま state に反映する。
+      const updated = await addHistoryEntry(result, history);
+      setHistory(updated);
 
       return result;
     } finally {
       writingRef.current = false;
     }
-  }, [hasDrawnToday, fortune, loadHistory]);
+  }, [hasDrawnToday, fortune, history]);
 
   const resetFortune = useCallback(() => {
     if (!hasDrawnToday) {

--- a/utils/HistoryStorage.ts
+++ b/utils/HistoryStorage.ts
@@ -45,18 +45,30 @@ export async function getHistory(): Promise<HistoryEntry[]> {
 }
 
 /**
- * 履歴に新しいエントリを追加する
+ * 履歴に新しいエントリを追加し、更新後の履歴配列を返す。
+ *
+ * `currentHistory` を渡すと AsyncStorage からの再読込を省略できる。
+ * 呼び出し元が既に state として履歴を保持している場合はそれを渡すことで、
+ * 同一データの JSON parse + migrate map を重複実行せずに済む。
+ * 省略時は従来通り内部で `getHistory()` を実行する。
+ *
+ * 失敗時は `currentHistory`（渡されていれば）または空配列を返す（silent error）。
  */
-export async function addHistoryEntry(result: FortuneResult): Promise<void> {
+export async function addHistoryEntry(
+  result: FortuneResult,
+  currentHistory?: HistoryEntry[]
+): Promise<HistoryEntry[]> {
   try {
-    const history = await getHistory();
+    const history = currentHistory ?? (await getHistory());
     // 最新のものが先頭に来るように追加し、50件に制限
     const updatedHistory = [result, ...history].slice(0, MAX_HISTORY_ITEMS);
     await AsyncStorage.setItem(HISTORY_KEY, JSON.stringify(updatedHistory));
 
     await setLastDrawDate(getTodayString());
+    return updatedHistory;
   } catch (error) {
     reportStorageError("addHistoryEntry", error);
+    return currentHistory ?? [];
   }
 }
 

--- a/utils/__tests__/HistoryStorage.test.ts
+++ b/utils/__tests__/HistoryStorage.test.ts
@@ -81,6 +81,44 @@ describe("HistoryStorage", () => {
     expect(savedData[1]).toEqual(mockHistoryData[0]);
   });
 
+  it("addHistoryEntry returns the updated history array", async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(mockHistoryData));
+    const newEntry: HistoryEntry = {
+      ...mockHistoryData[0],
+      id: "2",
+    };
+
+    const updated = await addHistoryEntry(newEntry);
+
+    expect(updated).toHaveLength(2);
+    expect(updated[0]).toEqual(newEntry);
+    expect(updated[1]).toEqual(mockHistoryData[0]);
+  });
+
+  it("addHistoryEntry skips AsyncStorage.getItem when currentHistory is provided", async () => {
+    const newEntry: HistoryEntry = {
+      ...mockHistoryData[0],
+      id: "injected",
+    };
+
+    const updated = await addHistoryEntry(newEntry, mockHistoryData);
+
+    expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+    expect(updated).toHaveLength(2);
+    expect(updated[0]).toEqual(newEntry);
+  });
+
+  it("addHistoryEntry returns the provided currentHistory when setItem throws", async () => {
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error("disk full"));
+    const newEntry: HistoryEntry = { ...mockHistoryData[0], id: "3" };
+
+    const updated = await addHistoryEntry(newEntry, mockHistoryData);
+
+    expect(updated).toEqual(mockHistoryData);
+    consoleSpy.mockRestore();
+  });
+
   it("clearHistory clears storage", async () => {
     await clearHistory();
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith(HISTORY_KEY);


### PR DESCRIPTION
## 目的

複数エージェント品質監査の **P1 指摘** に対応。`drawFortune` 実行時に「`addHistoryEntry`（内部で `getHistory`）→ `loadHistory`（再度 `getHistory`）」が直列に走り、同一データの JSON parse + migrate map が 2 回行われていた。SHAKING → DRAWING のタイマーがこの書込みを await するため、抽選アニメ完了から結果表示までの体感速度を押し下げていた。

## 変更点

### `utils/HistoryStorage.ts`

- `addHistoryEntry` の戻り値を `Promise<void>` → `Promise<HistoryEntry[]>`（更新後配列）に変更
- 第 2 引数 `currentHistory?: HistoryEntry[]` を追加。呼び出し元が既に state として保持している履歴を渡せば内部の `getHistory()` を省略できる
- 失敗時は `currentHistory ?? []` を返して silent error と整合

### `hooks/useOmikujiLogic.ts`

- `addHistoryEntry(result, history)` を呼び、戻り値で `setHistory(updated)`
- `loadHistory()` の再実行を廃止

### `utils/__tests__/HistoryStorage.test.ts`

3 ケース追加:
- `addHistoryEntry` が更新後配列を返す
- `currentHistory` を渡すと `AsyncStorage.getItem` が呼ばれない
- `setItem` throw 時に `currentHistory` が返る

## 期待効果

- 抽選 1 回あたり `getHistory` 呼び出し **2 → 0**（state 注入 + 以降の画面表示は既に state を使用）
- 書込み前の parse + migrate が省略され、監査推定で **30〜80ms の I/O 短縮**

## 後方互換

`addHistoryEntry(result)` の 1 引数呼び出しは従来通り `getHistory()` を実行するので、他コード・将来の呼び出し元は無影響。

## テスト結果

- `pnpm lint`: ✅
- `pnpm tsc --noEmit`: ✅
- `pnpm test`: ✅ **45 suites / 312 tests passed**（+3）

## 参考 (監査指摘)

performance-optimizer:
> addHistoryEntry が「getHistory → 配列再生成 → setItem」を直列実行し、直後に useOmikujiLogic.drawFortune がさらに loadHistory で同じ getHistory を再実行する。useAppStateMachine の SHAKING→DRAWING タイマーはこの Promise を await するため、書込み I/O が体感の「結果が出るまでの間」を直接押し下げる。