### PR TITLE
[security] CSP script-src から 'unsafe-eval' を撤去 (監査P2)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: "html",
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000",
     locale: "ja-JP",
     trace: "on-first-retry",
   },
@@ -29,8 +29,8 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: "pnpm build && pnpm exec serve -s dist -p 3000",
-    url: "http://localhost:3000",
+    command: `pnpm build && pnpm exec serve -s dist -p ${process.env.PLAYWRIGHT_WEB_PORT ?? 3000}`,
+    url: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 240 * 1000,
   },

--- a/vercel.json
+++ b/vercel.json
@@ -1,87 +1,85 @@
 {
-    "git": {
-        "deploymentEnabled": false
+  "git": {
+    "deploymentEnabled": false
+  },
+  "buildCommand": "pnpm build",
+  "outputDirectory": "dist",
+  "installCommand": "pnpm install",
+  "framework": null,
+  "cleanUrls": true,
+  "regions": ["hnd1"],
+  "trailingSlash": false,
+  "rewrites": [
+    {
+      "source": "/((?!_expo|assets|fonts|favicon\\.ico|.*\\..*).*)",
+      "destination": "/index.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(assets|fonts|_expo)/:path*",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
     },
-    "buildCommand": "pnpm build",
-    "outputDirectory": "dist",
-    "installCommand": "pnpm install",
-    "framework": null,
-    "cleanUrls": true,
-    "regions": [
-        "hnd1"
-    ],
-    "trailingSlash": false,
-    "rewrites": [
+    {
+      "source": "/(.*).:ext(png|jpg|jpeg|gif|webp|avif|svg|ico)",
+      "headers": [
         {
-            "source": "/((?!_expo|assets|fonts|favicon\\.ico|.*\\..*).*)",
-            "destination": "/index.html"
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
         }
-    ],
-    "headers": [
+      ]
+    },
+    {
+      "source": "/(.*).:ext(mp3|wav|ogg|m4a)",
+      "headers": [
         {
-            "source": "/(assets|fonts|_expo)/:path*",
-            "headers": [
-                {
-                    "key": "Cache-Control",
-                    "value": "public, max-age=31536000, immutable"
-                }
-            ]
-        },
-        {
-            "source": "/(.*).:ext(png|jpg|jpeg|gif|webp|avif|svg|ico)",
-            "headers": [
-                {
-                    "key": "Cache-Control",
-                    "value": "public, max-age=31536000, immutable"
-                }
-            ]
-        },
-        {
-            "source": "/(.*).:ext(mp3|wav|ogg|m4a)",
-            "headers": [
-                {
-                    "key": "Cache-Control",
-                    "value": "public, max-age=31536000, immutable"
-                }
-            ]
-        },
-        {
-            "source": "/(.*).:ext(html)",
-            "headers": [
-                {
-                    "key": "Cache-Control",
-                    "value": "public, max-age=0, must-revalidate"
-                }
-            ]
-        },
-        {
-            "source": "/(.*)",
-            "headers": [
-                {
-                    "key": "X-Content-Type-Options",
-                    "value": "nosniff"
-                },
-                {
-                    "key": "X-Frame-Options",
-                    "value": "DENY"
-                },
-                {
-                    "key": "Referrer-Policy",
-                    "value": "strict-origin-when-cross-origin"
-                },
-                {
-                    "key": "Content-Security-Policy",
-                    "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' https:; frame-ancestors 'none'"
-                },
-                {
-                    "key": "Permissions-Policy",
-                    "value": "accelerometer=(self), gyroscope=(self), magnetometer=(self)"
-                },
-                {
-                    "key": "Strict-Transport-Security",
-                    "value": "max-age=31536000; includeSubDomains; preload"
-                }
-            ]
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
         }
-    ]
+      ]
+    },
+    {
+      "source": "/(.*).:ext(html)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' https:; frame-ancestors 'none'"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "accelerometer=(self), gyroscope=(self), magnetometer=(self)"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains; preload"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## 目的

監査 P2 指摘「CSP に `'unsafe-eval'` が含まれ、万一の XSS 時の被害拡大リスクになる」に対応。F (#379) で `react-native-reanimated` を Web bundle から除外したことで worklet の eval 要求は消えており、撤去の前提条件が整った。

## 変更点

### `vercel.json`

`Content-Security-Policy` の `script-src` から `'unsafe-eval'` を削除。

```diff
-"script-src 'self' 'unsafe-inline' 'unsafe-eval'"
+"script-src 'self' 'unsafe-inline'"
```

### `playwright.config.ts`

ローカル環境で他プロジェクトが 3000 ポートを占有している場合の干渉を避けられるよう、`baseURL` / `webServer` のポートを環境変数 `PLAYWRIGHT_BASE_URL` / `PLAYWRIGHT_WEB_PORT` で上書き可能に。デフォルトは従来通り 3000。

## bundle 内 eval の解析

撤去後に bundle へ残る `eval(...)` は以下 2 箇所のみで、**いずれも Web ランタイムで発火しない経路**です:

| # | 場所 | 発火条件 | Web での到達可能性 |
|---|---|---|---|
| 1 | `uuidv4` の Node.js フォールバック | `typeof window === 'undefined' && typeof crypto === 'undefined'` | **到達不能**（ブラウザは window を常に持つ） |
| 2 | Expo Router の split-bundle loader の `eval(body)` | 分割バンドルを fetch した成功レスポンスで発火 | **到達不能**（現状 code splitting 無効 / 単一 entry） |

ブラウザ CSP は eval の **実行時** に違反検出するため、コードが存在するだけでは違反にならない想定です。

## テスト結果

- `pnpm lint`: ✅
- `pnpm tsc --noEmit`: ✅
- `pnpm test`: ✅ 45 suites / 312 tests passed（挙動変更なし）
- `pnpm test:e2e:web` (chromium, port 3101): ✅ **5/5 passed**
  - home タイトル / 抽選フロー / overlay focus trap / history 遷移 / privacy 遷移

## 本番 preview での最終確認を推奨

Vercel preview URL で以下を目視してからマージ/本番反映してください:
- ブラウザ DevTools コンソールに `Content-Security-Policy` 違反ログが出ないこと
- 抽選 → 結果 → シェア → 履歴 の一連のフローが動作すること

## 参考 (監査指摘)

security-auditor (P2):
> `'unsafe-eval'` は通常不要。残すと万一の XSS（i18n テンプレ汚染や将来のユーザ入力導入時）で被害が拡大する。一度外してビルド・E2E を回し、Reanimated worklet の評価が CSP 違反を出さないか確認。react-native-web 0.21 + Reanimated 4 は worklet を Function コンストラクタで生成しないケースが多い。