### PR TITLE
[chore] v1.3.0 version bump

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "デジタルおみくじ",
     "slug": "digital-omikuji",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "orientation": "portrait",
     "userInterfaceStyle": "light",
     "icon": "./assets/icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digital-omikuji",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "expo-router/entry",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## 目的

v1.2.0 → v1.3.0 への version bump。直後の release PR (`develop` → `main`) に含めて本番反映する。

## v1.2.0 以降の累積変更ハイライト

### 機能追加
- **設定画面**: シェイク無効化 / モーション軽減を OS 設定と独立に切替可能 (#372, closes #180)

### 品質・信頼性
- **domain 層抽出**: 純粋ロジックを React/Expo 非依存の層に分離 (#362, #365-#369)
- **drawFortune 書込みレース防止**: 多重呼出しで履歴が二重保存されないよう ref ガード (#375)
- **SHAKING 状態の a11y live region**: SR ユーザに進捗アナウンス (#376)

### パフォーマンス
- dist 配信物 45MB → **20MB**（フォントサブパス import、#373）
- Web entry JS 3.1MB → **2.1MB**（metro alias で reanimated/view-shot 除外、#379）
- 抽選時の AsyncStorage 再読込を排除（#377）

### セキュリティ
- Dependabot high 脆弱性 17 → **0**（#370, #371）
- Sentry PII 防御・Android 不要権限削除（#378）
- CSP `'unsafe-eval'` 撤去（#380）

### テスト
- 281 → **312 tests** (+31)
- Web 共有成功パス / `useReducedMotion` / `useSoundEffects` の spec 追加

## テスト結果

- `pnpm lint`: ✅
- `pnpm tsc --noEmit`: ✅
- `pnpm test`: ✅ 45 suites / 312 tests passed
- `pnpm build`: ✅ dist 19MB