### PR TITLE
[chore] CI Node を 22 LTS に引き上げて undici 6.25+ と整合

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -5,7 +5,10 @@ inputs:
   node-version:
     description: "Node.js version to install"
     required: false
-    default: "20"
+    # Node 22 LTS 以上を既定値に採用する。
+    # undici 6.25+ が Node の内部 webidl API (markAsUncloneable 等、Node 21+)
+    # に依存するため、Node 20 だと @sentry/cli の postinstall が落ちる。
+    default: "22"
   install-dependencies:
     description: "Whether to run pnpm install --frozen-lockfile --prefer-offline"
     required: false

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.0",
   "main": "expo-router/entry",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "packageManager": "pnpm@9.15.2",
   "scripts": {


### PR DESCRIPTION
## 背景

release PR #390 の CI 実行で、`@sentry/cli` の postinstall が以下のエラーで落ちていた:

```
TypeError: webidl.util.markAsUncloneable is not a function
    at new CacheStorage (.../undici/lib/web/cache/cachestorage.js:20:17)
    at Object.<anonymous> (.../undici/index.js:179:25)
```

これは #370 の `pnpm.overrides` で undici を `>=6.25.0` に固定した副作用。undici 6.25+ は Node の内部 webidl API（`markAsUncloneable` など）を利用しており、これは **Node 21+ で追加された API**。CI の既定 Node 20 では未提供のため setup 段階で失敗する（ローカルは Node 25 で成功していた）。

develop の過去 PR が pass していたのは、pnpm-lock の状態が CI キャッシュから再利用され、postinstall が skip されていたため。release PR はベースが main で差分が大きく、pnpm install がフルで走った結果、問題が顕在化した。

## 変更点

### `.github/actions/setup-environment/action.yml`

`node-version` の default を `"20"` → `"22"` に変更し、コメントで依存の背景を記述。全ワークフロー (`ci` / `deploy-vercel` / `e2e-web` / `e2e` / `river-reviewer`) はこの composite action 経由なので、一括で Node 22 系に切り替わる。

### `package.json`

`engines.node` を `">=20"` → `">=22"` に引き上げ、方針を明示。

## リスク

- Node 22 は LTS で、Expo SDK 54 / React Native 0.79 も公式対応済み
- CI runner の `actions/setup-node@v6` は Node 22 を問題なく提供
- ローカル開発者は Node 22 以上が要件になる（既に大半がクリア）

## 次ステップ

本 PR マージ後、release PR #390 を develop 最新に同期して再実行すれば CI が通る見込み。

## テスト結果

変更は CI 環境依存のため、マージ後の GitHub Actions で green になることで検証する。ローカルの lint/tsc/test は従来通り green。