### PR TITLE
feat(ui): UI/UX改善 — トークン統一・ハプティクス・遷移・演出強化

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -36,8 +36,20 @@ function RootLayout() {
   }
 
   return (
-    <Stack screenOptions={{ headerShown: false }}>
+    <Stack screenOptions={{ headerShown: false, animation: "fade" }}>
       <Stack.Screen name="index" />
+      <Stack.Screen
+        name="history"
+        options={{ animation: "slide_from_bottom" }}
+      />
+      <Stack.Screen
+        name="settings"
+        options={{ animation: "slide_from_bottom" }}
+      />
+      <Stack.Screen
+        name="privacy-policy"
+        options={{ animation: "slide_from_right" }}
+      />
     </Stack>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -38,18 +38,9 @@ function RootLayout() {
   return (
     <Stack screenOptions={{ headerShown: false, animation: "fade" }}>
       <Stack.Screen name="index" />
-      <Stack.Screen
-        name="history"
-        options={{ animation: "slide_from_bottom" }}
-      />
-      <Stack.Screen
-        name="settings"
-        options={{ animation: "slide_from_bottom" }}
-      />
-      <Stack.Screen
-        name="privacy-policy"
-        options={{ animation: "slide_from_right" }}
-      />
+      <Stack.Screen name="history" options={{ animation: "slide_from_bottom" }} />
+      <Stack.Screen name="settings" options={{ animation: "slide_from_bottom" }} />
+      <Stack.Screen name="privacy-policy" options={{ animation: "slide_from_right" }} />
     </Stack>
   );
 }

--- a/app/history.tsx
+++ b/app/history.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { HistoryEntry, clearHistory, getHistory } from "../utils/HistoryStorage";
 import { navigateBackOrReplace } from "../utils/navigation";
 import { VersionDisplay } from "../components/VersionDisplay";
-import { HistoryScreenTemplate } from "../components/templates/HistoryScreenTemplate";
+import { SubScreenTemplate } from "../components/templates/SubScreenTemplate";
 import { PageHeader } from "../components/design-system/PageHeader";
 import { Button } from "../components/design-system/Button";
 import { HistoryListPattern } from "../components/patterns/HistoryListPattern";
@@ -75,7 +75,7 @@ export default function HistoryScreen() {
   );
 
   return (
-    <HistoryScreenTemplate
+    <SubScreenTemplate
       header={header}
       content={
         isLoading ? (

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -63,7 +63,7 @@ export default function OmikujiApp() {
   );
 
   const historyAction = (
-    <View style={{ flexDirection: "row", gap: 8 }}>
+    <View className="flex-row gap-2">
       <Button
         label="履歴"
         onPress={() => router.push("/history")}

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -4,9 +4,11 @@ import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { useAppSettings } from "../hooks/useAppSettings";
 import { navigateBackOrReplace } from "../utils/navigation";
+import { getStringToken } from "../design-system";
 import { VersionDisplay } from "../components/VersionDisplay";
-import { HistoryScreenTemplate } from "../components/templates/HistoryScreenTemplate";
+import { SubScreenTemplate } from "../components/templates/SubScreenTemplate";
 import { PageHeader } from "../components/design-system/PageHeader";
+import { SurfaceCard } from "../components/design-system/SurfaceCard";
 import { Button } from "../components/design-system/Button";
 
 export default function SettingsScreen() {
@@ -50,7 +52,7 @@ export default function SettingsScreen() {
     </ScrollView>
   );
 
-  return <HistoryScreenTemplate header={header} content={content} footer={<VersionDisplay />} />;
+  return <SubScreenTemplate header={header} content={content} footer={<VersionDisplay />} />;
 }
 
 interface SettingRowProps {
@@ -63,15 +65,7 @@ interface SettingRowProps {
 
 function SettingRow({ label, description, value, disabled, onChange }: SettingRowProps) {
   return (
-    <View
-      style={{
-        backgroundColor: "rgba(255,255,255,0.06)",
-        borderRadius: 16,
-        borderWidth: 1,
-        borderColor: "rgba(255,255,255,0.12)",
-        padding: 16,
-      }}
-    >
+    <SurfaceCard variant="glassCard" style={{ padding: 16 }}>
       <View
         style={{
           flexDirection: "row",
@@ -82,7 +76,7 @@ function SettingRow({ label, description, value, disabled, onChange }: SettingRo
       >
         <Text
           style={{
-            color: "white",
+            color: getStringToken("semantic.text.primary"),
             fontSize: 16,
             fontWeight: "600",
             flexShrink: 1,
@@ -99,7 +93,7 @@ function SettingRow({ label, description, value, disabled, onChange }: SettingRo
       </View>
       <Text
         style={{
-          color: "rgba(255,255,255,0.74)",
+          color: getStringToken("semantic.text.muted"),
           fontSize: 13,
           lineHeight: 20,
           marginTop: 8,
@@ -107,6 +101,6 @@ function SettingRow({ label, description, value, disabled, onChange }: SettingRo
       >
         {description}
       </Text>
-    </View>
+    </SurfaceCard>
   );
 }

--- a/components/design-system/Button.tsx
+++ b/components/design-system/Button.tsx
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { Pressable, StyleProp, Text, TextStyle, ViewStyle } from "react-native";
+import * as Haptics from "expo-haptics";
 import { getComponentTokens, getStringToken } from "../../design-system";
+import { triggerHaptic } from "../../utils/haptics";
 
 type ButtonVariant = "primaryRitual" | "secondaryQuiet" | "utilityWarm" | "textLink";
 
@@ -43,9 +45,16 @@ export function Button({
   const fontFamily =
     variant === "primaryRitual" ? getStringToken("primitive.typography.family.ritual") : undefined;
 
+  const handlePress = useCallback(() => {
+    if (variant !== "textLink") {
+      triggerHaptic({ type: "impact", style: Haptics.ImpactFeedbackStyle.Light });
+    }
+    onPress();
+  }, [variant, onPress]);
+
   return (
     <Pressable
-      onPress={onPress}
+      onPress={handlePress}
       accessibilityRole="button"
       accessibilityLabel={accessibilityLabel ?? label}
       accessibilityHint={accessibilityHint}

--- a/components/design-system/Button.tsx
+++ b/components/design-system/Button.tsx
@@ -3,6 +3,7 @@ import { Pressable, StyleProp, Text, TextStyle, ViewStyle } from "react-native";
 import * as Haptics from "expo-haptics";
 import { getComponentTokens, getStringToken } from "../../design-system";
 import { triggerHaptic } from "../../utils/haptics";
+import { useReducedMotion } from "../../hooks/useReducedMotion";
 
 type ButtonVariant = "primaryRitual" | "secondaryQuiet" | "utilityWarm" | "textLink";
 
@@ -42,15 +43,21 @@ export function Button({
     textSize: number;
   }>(`button.${variant}`);
 
+  const reducedMotion = useReducedMotion();
+
   const fontFamily =
     variant === "primaryRitual" ? getStringToken("primitive.typography.family.ritual") : undefined;
 
   const handlePress = useCallback(() => {
     if (variant !== "textLink") {
-      triggerHaptic({ type: "impact", style: Haptics.ImpactFeedbackStyle.Light });
+      triggerHaptic(
+        { type: "impact", style: Haptics.ImpactFeedbackStyle.Light },
+        false,
+        reducedMotion
+      );
     }
     onPress();
-  }, [variant, onPress]);
+  }, [variant, onPress, reducedMotion]);
 
   return (
     <Pressable

--- a/components/design-system/HistoryItemCard.tsx
+++ b/components/design-system/HistoryItemCard.tsx
@@ -24,7 +24,12 @@ interface HistoryItemCardProps {
   onPress?: () => void;
 }
 
-export function HistoryItemCard({ item, fortuneTitle, fortuneMessage, onPress }: HistoryItemCardProps) {
+export function HistoryItemCard({
+  item,
+  fortuneTitle,
+  fortuneMessage,
+  onPress,
+}: HistoryItemCardProps) {
   const tokens = getComponentTokens<{
     metaColor: string;
     bodyColor: string;

--- a/components/design-system/HistoryItemCard.tsx
+++ b/components/design-system/HistoryItemCard.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Pressable, Text, View } from "react-native";
 import { HistoryEntry } from "../../utils/HistoryStorage";
 import { getComponentTokens, getStringToken } from "../../design-system";
@@ -45,13 +44,8 @@ export function HistoryItemCard({
   // スクリーンリーダーでは「大吉。2026年4月11日 09:30。最高の運気です。」のように読み上げる
   const combinedA11yLabel = `${fortuneTitle}。${formattedDate}。${fortuneMessage}`;
 
-  const card = (
-    <SurfaceCard
-      variant="glassCard"
-      accessible
-      accessibilityLabel={combinedA11yLabel}
-      accessibilityRole="summary"
-    >
+  const cardContent = (
+    <>
       <View style={{ flexDirection: "row", justifyContent: "space-between", gap: 16 }}>
         <Text
           style={{
@@ -77,14 +71,30 @@ export function HistoryItemCard({
       >
         {fortuneMessage}
       </Text>
-    </SurfaceCard>
+    </>
   );
 
-  if (!onPress) return card;
+  if (!onPress) {
+    return (
+      <SurfaceCard
+        variant="glassCard"
+        accessible
+        accessibilityLabel={combinedA11yLabel}
+        accessibilityRole="summary"
+      >
+        {cardContent}
+      </SurfaceCard>
+    );
+  }
 
   return (
-    <Pressable onPress={onPress} style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}>
-      {card}
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={combinedA11yLabel}
+      style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+    >
+      <SurfaceCard variant="glassCard">{cardContent}</SurfaceCard>
     </Pressable>
   );
 }

--- a/components/design-system/HistoryItemCard.tsx
+++ b/components/design-system/HistoryItemCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Text, View } from "react-native";
+import { Pressable, Text, View } from "react-native";
 import { HistoryEntry } from "../../utils/HistoryStorage";
 import { getComponentTokens, getStringToken } from "../../design-system";
 import { getFortuneLevelColor } from "../../design-system/fortuneTokens";
@@ -21,9 +21,10 @@ interface HistoryItemCardProps {
   item: HistoryEntry;
   fortuneTitle: string;
   fortuneMessage: string;
+  onPress?: () => void;
 }
 
-export function HistoryItemCard({ item, fortuneTitle, fortuneMessage }: HistoryItemCardProps) {
+export function HistoryItemCard({ item, fortuneTitle, fortuneMessage, onPress }: HistoryItemCardProps) {
   const tokens = getComponentTokens<{
     metaColor: string;
     bodyColor: string;
@@ -39,7 +40,7 @@ export function HistoryItemCard({ item, fortuneTitle, fortuneMessage }: HistoryI
   // スクリーンリーダーでは「大吉。2026年4月11日 09:30。最高の運気です。」のように読み上げる
   const combinedA11yLabel = `${fortuneTitle}。${formattedDate}。${fortuneMessage}`;
 
-  return (
+  const card = (
     <SurfaceCard
       variant="glassCard"
       accessible
@@ -72,5 +73,13 @@ export function HistoryItemCard({ item, fortuneTitle, fortuneMessage }: HistoryI
         {fortuneMessage}
       </Text>
     </SurfaceCard>
+  );
+
+  if (!onPress) return card;
+
+  return (
+    <Pressable onPress={onPress} style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}>
+      {card}
+    </Pressable>
   );
 }

--- a/components/patterns/ShakingPattern.tsx
+++ b/components/patterns/ShakingPattern.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Text } from "react-native";
+import { Text, View } from "react-native";
 import { MotionView } from "../design-system/MotionView";
 import { getStringToken } from "../../design-system";
 
@@ -7,27 +7,80 @@ interface ShakingPatternProps {
   reducedMotion?: boolean;
 }
 
+const SPARKLE_CONFIGS = [
+  { x: -60, y: -50, delay: 0, size: 6 },
+  { x: 55, y: -40, delay: 120, size: 8 },
+  { x: -45, y: 30, delay: 240, size: 5 },
+  { x: 50, y: 45, delay: 360, size: 7 },
+  { x: 0, y: -65, delay: 180, size: 6 },
+];
+
 export function ShakingPattern({ reducedMotion = false }: ShakingPatternProps) {
   const accentColor = getStringToken("semantic.text.accent");
   return (
-    <MotionView
-      from={{ translateX: -12, rotateZ: "-8deg", scale: 0.96 }}
-      animate={{
-        translateX: reducedMotion ? [-4, 4, -4] : [-16, 16, -16, 16, 0],
-        rotateZ: reducedMotion ? "-2deg" : ["-10deg", "10deg", "0deg"],
-        scale: reducedMotion ? 1 : [0.96, 1.06, 1],
-      }}
-      transition={{ type: "timing", duration: 90, loop: true }}
+    <View
       style={{ alignItems: "center" }}
-      // スクリーンリーダー向けの進捗フィードバック。SHAKING 中の数秒間に
-      // 状況が伝わらないと VoiceOver / TalkBack ユーザーが「固まった」と
-      // 誤認するため、progressbar role と live region でアナウンスする。
       accessible
       accessibilityRole="progressbar"
       accessibilityLabel="念を込めてシェイクしています"
       accessibilityLiveRegion="polite"
     >
-      <Text style={{ fontSize: 92 }}>🫨</Text>
+      <View style={{ alignItems: "center", justifyContent: "center" }}>
+        {!reducedMotion && (
+          <MotionView
+            from={{ opacity: 0, scale: 0.6 }}
+            animate={{ opacity: 0.35, scale: 1.3 }}
+            transition={{ type: "timing", duration: 800, loop: true, repeatReverse: true }}
+            style={{
+              position: "absolute",
+              width: 180,
+              height: 180,
+              borderRadius: 90,
+              backgroundColor: accentColor,
+            }}
+          />
+        )}
+
+        {!reducedMotion &&
+          SPARKLE_CONFIGS.map((spark, i) => (
+            <MotionView
+              key={i}
+              from={{ opacity: 0, scale: 0.3 }}
+              animate={{ opacity: [0, 1, 0], scale: [0.3, 1, 0.3] }}
+              transition={{
+                type: "timing",
+                duration: 600,
+                delay: spark.delay,
+                loop: true,
+              }}
+              style={{
+                position: "absolute",
+                left: "50%",
+                top: "50%",
+                marginLeft: spark.x - spark.size / 2,
+                marginTop: spark.y - spark.size / 2,
+                width: spark.size,
+                height: spark.size,
+                borderRadius: spark.size / 2,
+                backgroundColor: accentColor,
+              }}
+            />
+          ))}
+
+        <MotionView
+          from={{ translateX: -12, rotateZ: "-8deg", scale: 0.96 }}
+          animate={{
+            translateX: reducedMotion ? [-4, 4, -4] : [-16, 16, -16, 16, 0],
+            rotateZ: reducedMotion ? "-2deg" : ["-10deg", "10deg", "0deg"],
+            scale: reducedMotion ? 1 : [0.96, 1.06, 1],
+          }}
+          transition={{ type: "timing", duration: 90, loop: true }}
+          style={{ alignItems: "center" }}
+        >
+          <Text style={{ fontSize: 92 }}>🫨</Text>
+        </MotionView>
+      </View>
+
       <MotionView
         from={{ opacity: 0.65, scale: 1 }}
         animate={{ opacity: 1, scale: 1.08 }}
@@ -53,6 +106,6 @@ export function ShakingPattern({ reducedMotion = false }: ShakingPatternProps) {
           念を込めて...
         </Text>
       </MotionView>
-    </MotionView>
+    </View>
   );
 }

--- a/components/templates/HistoryScreenTemplate.tsx
+++ b/components/templates/HistoryScreenTemplate.tsx
@@ -1,26 +1,2 @@
-import React from "react";
-import { View } from "react-native";
-import { getStringToken } from "../../design-system";
-
-interface HistoryScreenTemplateProps {
-  header: React.ReactNode;
-  content: React.ReactNode;
-  footer?: React.ReactNode;
-}
-
-export function HistoryScreenTemplate({ header, content, footer }: HistoryScreenTemplateProps) {
-  return (
-    <View
-      style={{
-        flex: 1,
-        backgroundColor: getStringToken("semantic.surface.experience.canvas"),
-        paddingHorizontal: 16,
-        paddingTop: 48,
-      }}
-    >
-      {header}
-      <View style={{ flex: 1, marginTop: 20 }}>{content}</View>
-      {footer ? <View style={{ paddingBottom: 12 }}>{footer}</View> : null}
-    </View>
-  );
-}
+/** @deprecated Import from SubScreenTemplate instead */
+export { SubScreenTemplate as HistoryScreenTemplate } from "./SubScreenTemplate";

--- a/components/templates/SubScreenTemplate.tsx
+++ b/components/templates/SubScreenTemplate.tsx
@@ -24,6 +24,3 @@ export function SubScreenTemplate({ header, content, footer }: SubScreenTemplate
     </View>
   );
 }
-
-/** @deprecated Use SubScreenTemplate instead */
-export const HistoryScreenTemplate = SubScreenTemplate;

--- a/components/templates/SubScreenTemplate.tsx
+++ b/components/templates/SubScreenTemplate.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { View } from "react-native";
+import { getStringToken } from "../../design-system";
+
+interface SubScreenTemplateProps {
+  header: React.ReactNode;
+  content: React.ReactNode;
+  footer?: React.ReactNode;
+}
+
+export function SubScreenTemplate({ header, content, footer }: SubScreenTemplateProps) {
+  return (
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: getStringToken("semantic.surface.experience.canvas"),
+        paddingHorizontal: 16,
+        paddingTop: 48,
+      }}
+    >
+      {header}
+      <View style={{ flex: 1, marginTop: 20 }}>{content}</View>
+      {footer ? <View style={{ paddingBottom: 12 }}>{footer}</View> : null}
+    </View>
+  );
+}
+
+/** @deprecated Use SubScreenTemplate instead */
+export const HistoryScreenTemplate = SubScreenTemplate;


### PR DESCRIPTION
## Summary
- Settings画面のハードコードされた`rgba()`スタイルを`SurfaceCard`+デザイントークンに統一
- 全ボタン（textLink除く）に軽いハプティクスフィードバックを追加
- 画面遷移にfade/slide_from_bottomアニメーションを導入
- シェイク演出に背景グロー＋スパークルパーティクル5つを追加（reducedMotion対応）
- 履歴カードにタップ可能な`Pressable`ラッパーと`onPress` propを追加
- `HistoryScreenTemplate`→`SubScreenTemplate`にリネーム（後方互換re-export付き）
- ホーム画面のインラインスタイルをNativeWindクラスに移行

## Test plan
- [ ] `npx tsc --noEmit` 型チェック通過を確認
- [ ] `npm test` 既存テスト通過を確認（タイムアウト系は変更前から存在）
- [ ] Web: トップ画面 → 履歴/設定画面の遷移アニメーション確認
- [ ] Web: おみくじを引く → シェイク中のグロー＋スパークル表示確認
- [ ] Web: 設定画面のカードスタイルがglassCard準拠であること確認
- [ ] iOS/Android: ボタン押下時にハプティクスフィードバックがあること確認
- [ ] reducedMotion有効時: スパークル非表示、アニメーション簡素化を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)