### PR TITLE
chore(process): dependabot連鎖競合の構造防止 + gh複数垢push知見の明文化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,15 @@ updates:
           - "eslint*"
           - "prettier*"
           - "markdownlint*"
+      # 上記の専用グループに該当しない依存の minor / patch を 1 本に集約する。
+      # 単体PRが乱立すると、1件マージするたび他PRの pnpm-lock.yaml が
+      # 競合(DIRTY)化し recreate の往復が発生するため、構造的に抑制する。
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "npm"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,30 @@
+name: Dependabot auto-merge
+
+# dependabot の minor / patch 更新は CI 通過後に自動マージする。
+# 単体PRが滞留すると pnpm-lock.yaml の連鎖競合(DIRTY)が発生し、
+# recreate の往復で運用コストが膨らむため、人手を介さず消化する。
+# major 更新は破壊的変更の可能性があるため自動マージ対象外（手動レビュー）。
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for non-major updates
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,11 @@ dependabot PR が複数滞留している場合、**1件ずつ手動マージし
 このリポジトリは push 権限が特定アカウント（例: `s977043`）に限定される。複数アカウントを`gh auth`に登録している場合の注意:
 
 - `gh auth token`は**非アクティブ垢のトークンを返すことがある**。push用は必ず`gh auth token --user <push権限垢>`で取得する。
-- `/tmp`配下のworktreeはgit credential helperを継承せず`could not read Password`で失敗する。`git push "https://x-access-token:$(gh auth token --user <垢>)@github.com/<owner>/<repo>.git" <branch>`でトークンURLを直書きする。
+- `/tmp`配下のworktreeはgit credential helperを継承せず`could not read Password`で失敗する。
+  - **推奨**: `gh auth switch --user <push権限垢> && gh auth setup-git` 後に通常の`git push`。gh のcredential helper経由でトークンが解決され、シェル履歴・プロセス一覧にトークンが残らない。
+  - 一時的に解決したい場合は credential helper をその場で渡す:
+    `git -c credential.helper='!f(){ echo username=x-access-token; echo "password=$(gh auth token --user <垢>)"; };f' push origin <branch>`
+  - **非推奨**: `https://x-access-token:<token>@github.com/...` のトークンURL直書き。シェル履歴・`ps`・reflog 等にトークンが露出するため使わない。
 - `.claude/worktrees/`配下のworktreeは親リポジトリの認証を継承するため通常pushでよい。
 
 ## 8. 並行タスク（Git Worktree）

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,24 @@ status: "active"
 - [ ] Copilot / Gemini / Codexのいずれかにレビュー依頼済み
 - [ ] `develop`をbaseにしている（例外: release PR, hotfix PR）
 
+### dependabot 大量PRの消化（ランブック）
+
+dependabot PR が複数滞留している場合、**1件ずつ手動マージしない**。1件マージするたび他PRの`pnpm-lock.yaml`が競合(DIRTY)化し、`recreate`待ち→再競合の往復で時間を浪費する。
+
+1. まず CI グリーンかつ`CLEAN`のものだけ先にマージする。
+2. 残りは個別にpollせず、`gh pr merge <n> --auto --squash --delete-branch`で**auto-merge**を仕掛ける（`.github/workflows/dependabot-auto-merge.yml`がminor/patchを自動処理）。
+3. `DIRTY`なものは`@dependabot recreate`をコメントし、auto-mergeに任せて放置する。
+4. CIが恒久的に失敗するもの（破壊的メジャー、非互換bump）はマージせず**理由付きでクローズ**する（例: SDK非互換の`expo-router`メジャー）。
+5. dependabotが無反応で最後の1件が`DIRTY`なら、worktreeで`git merge origin/develop`→`pnpm install --lockfile-only`→pushして手動解決する。
+
+### gh CLI 複数アカウント運用での push
+
+このリポジトリは push 権限が特定アカウント（例: `s977043`）に限定される。複数アカウントを`gh auth`に登録している場合の注意:
+
+- `gh auth token`は**非アクティブ垢のトークンを返すことがある**。push用は必ず`gh auth token --user <push権限垢>`で取得する。
+- `/tmp`配下のworktreeはgit credential helperを継承せず`could not read Password`で失敗する。`git push "https://x-access-token:$(gh auth token --user <垢>)@github.com/<owner>/<repo>.git" <branch>`でトークンURLを直書きする。
+- `.claude/worktrees/`配下のworktreeは親リポジトリの認証を継承するため通常pushでよい。
+
 ## 8. 並行タスク（Git Worktree）
 
 ### 目的


### PR DESCRIPTION
## Summary
直前の「オープンPR15件を全件マージ可能状態に対応」セッション（13マージ / #394・#381クローズ）の振り返りから、3件の改善を実装:

### A. ドキュメント追記（1件）
- `AGENTS.md` §7 に「gh CLI 複数アカウント運用での push」を追記。`gh auth token --user s977043` 必須・worktreeトークンURL直書き回避策（今回push 403で2回試行錯誤したため）

### B. 自動ガード（2件）
- `.github/dependabot.yml`: `minor-and-patch` catch-all グループ追加。単体PR乱立→`pnpm-lock.yaml`連鎖競合(DIRTY)を構造的に抑制（今回最大の時間損失要因）
- `.github/workflows/dependabot-auto-merge.yml`: minor/patch を CI 通過後に自動マージ。major は破壊的変更可能性のため対象外（手動レビュー）

### C. ツール運用（1件）
- `AGENTS.md` §7 に「dependabot 大量PRの消化ランブック」追記。個別pollせず auto-merge + recreate 前提で着手する手順を明文化

## Test plan
- [x] `python3 yaml.safe_load` で dependabot.yml / workflow の YAML 構文確認
- [x] `markdownlint AGENTS.md` 通過
- [x] workflow の actionlint は CI（actionlint.yml）で検証
- [x] `git add` は明示パスのみ（生成物・WIPを巻き込まない）

## 関連セッション
- 前回の振り返りPR: なし（本リポジトリ初回のプロセス改善PR）
- 対象セッションのマージ済みPR: #385,#386,#387,#388,#397,#399,#400,#401,#403,#404,#405,#406,#407
- クローズ: #394（#391/#405へ集約）, #381（expo-router v55 SDK非互換）
- 発生インシデント: dependabot連鎖lockfile競合の往復 / gh非アクティブ垢トークンによるpush 403 / #405レビュースレッド権限ゲート

🤖 Generated with [Claude Code](https://claude.com/claude-code)