### PR TITLE
chore(process): expo-router major更新をdependabot ignoreで恒久停止

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,14 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # expo-router のメジャー更新は Expo SDK 本体と密結合しており、
+      # SDK 54 固定のまま単体で上げると Web ビルド(expo-router/node/render.js)が
+      # 破損する。#381 / #410 で毎回クローズする恒久 toil となっていたため
+      # メジャーは無視し、Expo SDK アップグレード時に併せて対応する。
+      - dependency-name: "expo-router"
+        update-types:
+          - "version-update:semver-major"
     labels:
       - "dependencies"
       - "npm"


### PR DESCRIPTION
## Summary
2回目のセッション振り返り（#408マージ以降の増分）から、再発toilを1件、自動ガード化:

### B. 自動ガード（1件）
- `.github/dependabot.yml` に `expo-router` の **major更新ignore** を追加
- #381 / #410 で2回、SDK54非互換の `expo-router` メジャー(~6→~55)PRが生成され毎回クローズしていた恒久toilを構造的に停止
- Expo SDK 本体アップグレード時に expo-router を併せて対応する方針（minor/patchは従来どおり追従）

## Test plan
- [x] `python3 yaml.safe_load` で dependabot.yml の構文・ignore構造を確認
- [x] `git add` は明示パスのみ（生成物・WIPを巻き込まない）
- [x] push は AGENTS.md 推奨の credential.helper 方式（トークンURL非使用）でdogfood

## 関連セッション
- 前回の振り返りPR: #408（dependabot連鎖競合の構造防止 + gh複数垢push知見）
- 対象セッションのマージ済みPR: #409, #411
- 同一理由クローズPR: #381, #410（expo-router SDK非互換major）

🤖 Generated with [Claude Code](https://claude.com/claude-code)