### PR TITLE
feat(ui): MuteToggle脱絵文字化 + ハードコード色のトークン統一

### DIFF
--- a/components/design-system/Button.tsx
+++ b/components/design-system/Button.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback } from "react";
-import { Pressable, StyleProp, Text, TextStyle, ViewStyle } from "react-native";
+import React, { ReactNode, useCallback } from "react";
+import { Pressable, StyleProp, Text, TextStyle, View, ViewStyle } from "react-native";
 import * as Haptics from "expo-haptics";
 import { getComponentTokens, getStringToken } from "../../design-system";
 import { triggerHaptic } from "../../utils/haptics";
@@ -12,6 +12,7 @@ interface ButtonProps {
   onPress: () => void;
   variant?: ButtonVariant;
   icon?: string;
+  iconElement?: ReactNode;
   accessibilityLabel?: string;
   accessibilityHint?: string;
   style?: StyleProp<ViewStyle>;
@@ -24,6 +25,7 @@ export function Button({
   onPress,
   variant = "secondaryQuiet",
   icon,
+  iconElement,
   accessibilityLabel,
   accessibilityHint,
   style,
@@ -83,7 +85,9 @@ export function Button({
         style,
       ]}
     >
-      {icon ? (
+      {iconElement ? (
+        <View style={{ marginRight: 8 }}>{iconElement}</View>
+      ) : icon ? (
         <Text style={{ color: tokens.textColor, marginRight: 8, fontSize: tokens.textSize - 1 }}>
           {icon}
         </Text>

--- a/components/design-system/MuteToggle.tsx
+++ b/components/design-system/MuteToggle.tsx
@@ -1,5 +1,14 @@
-import React from "react";
+import { Text, View } from "react-native";
+import { getStringToken } from "../../design-system";
 import { Button } from "./Button";
+
+function BellIcon({ muted, color }: { muted: boolean; color: string }) {
+  return (
+    <View style={{ width: 20, height: 20, alignItems: "center", justifyContent: "center" }}>
+      <Text style={{ fontSize: 16, color, opacity: muted ? 0.5 : 1 }}>{muted ? "✕" : "♪"}</Text>
+    </View>
+  );
+}
 
 interface MuteToggleProps {
   isMuted: boolean;
@@ -7,10 +16,12 @@ interface MuteToggleProps {
 }
 
 export function MuteToggle({ isMuted, onToggle }: MuteToggleProps) {
+  const iconColor = getStringToken("semantic.text.primary");
+
   return (
     <Button
       label={isMuted ? "OFF" : "ON"}
-      icon={isMuted ? "🔕" : "🔔"}
+      iconElement={<BellIcon muted={isMuted} color={iconColor} />}
       onPress={onToggle}
       variant="secondaryQuiet"
       accessibilityLabel={isMuted ? "音声をオンにする" : "音声をオフにする"}

--- a/components/design-system/__tests__/MuteToggle.test.tsx
+++ b/components/design-system/__tests__/MuteToggle.test.tsx
@@ -3,21 +3,21 @@ import { fireEvent, render } from "@testing-library/react-native";
 import { MuteToggle } from "../MuteToggle";
 
 describe("MuteToggle", () => {
-  it("isMuted=false の場合は ON ラベルと 🔔 アイコンを表示する", () => {
+  it("isMuted=false の場合は ON ラベルと ♪ アイコンを表示する", () => {
     const { getByText, getByLabelText } = render(
       <MuteToggle isMuted={false} onToggle={jest.fn()} />
     );
     expect(getByText("ON")).toBeTruthy();
-    expect(getByText("🔔")).toBeTruthy();
+    expect(getByText("♪")).toBeTruthy();
     expect(getByLabelText("音声をオフにする")).toBeTruthy();
   });
 
-  it("isMuted=true の場合は OFF ラベルと 🔕 アイコンを表示する", () => {
+  it("isMuted=true の場合は OFF ラベルと ✕ アイコンを表示する", () => {
     const { getByText, getByLabelText } = render(
       <MuteToggle isMuted={true} onToggle={jest.fn()} />
     );
     expect(getByText("OFF")).toBeTruthy();
-    expect(getByText("🔕")).toBeTruthy();
+    expect(getByText("✕")).toBeTruthy();
     expect(getByLabelText("音声をオンにする")).toBeTruthy();
   });
 

--- a/components/patterns/IdleRitualPattern.tsx
+++ b/components/patterns/IdleRitualPattern.tsx
@@ -25,9 +25,9 @@ export function IdleRitualPattern({ hasDrawnToday, onDraw, onShowResult }: IdleR
           width: circleSize,
           height: circleSize,
           borderRadius: circleSize / 2,
-          backgroundColor: "rgba(255, 255, 255, 0.10)",
+          backgroundColor: getStringToken("semantic.surface.experience.glass"),
           borderWidth: 1,
-          borderColor: "rgba(255,255,255,0.20)",
+          borderColor: getStringToken("semantic.border.glass"),
           alignItems: "center",
           justifyContent: "center",
           marginBottom: isCompactHeight ? 16 : 24,
@@ -46,7 +46,7 @@ export function IdleRitualPattern({ hasDrawnToday, onDraw, onShowResult }: IdleR
 
       <Text
         style={{
-          color: "white",
+          color: getStringToken("semantic.text.primary"),
           fontSize: titleFontSize,
           lineHeight: titleLineHeight,
           textAlign: "center",
@@ -60,7 +60,7 @@ export function IdleRitualPattern({ hasDrawnToday, onDraw, onShowResult }: IdleR
       </Text>
       <Text
         style={{
-          color: "rgba(255,255,255,0.74)",
+          color: getStringToken("semantic.text.muted"),
           fontSize: isCompactHeight ? 14 : 15,
           lineHeight: isCompactHeight ? 22 : 24,
           textAlign: "center",
@@ -95,16 +95,16 @@ export function IdleRitualPattern({ hasDrawnToday, onDraw, onShowResult }: IdleR
             style={{
               marginTop: isCompactHeight ? 12 : 18,
               borderWidth: 1,
-              borderColor: "rgba(255,255,255,0.18)",
+              borderColor: getStringToken("semantic.border.soft"),
               borderRadius: 999,
               paddingHorizontal: isCompactHeight ? 14 : 16,
               paddingVertical: isCompactHeight ? 6 : 8,
-              backgroundColor: "rgba(255,255,255,0.08)",
+              backgroundColor: getStringToken("semantic.surface.experience.historyPlaceholder"),
             }}
           >
             <Text
               style={{
-                color: "rgba(255,255,255,0.82)",
+                color: getStringToken("semantic.text.muted"),
                 fontSize: isCompactHeight ? 11 : 12,
                 letterSpacing: isCompactHeight ? 1.4 : 2,
                 fontWeight: "700",

--- a/components/patterns/ShakingPattern.tsx
+++ b/components/patterns/ShakingPattern.tsx
@@ -87,7 +87,7 @@ export function ShakingPattern({ reducedMotion = false }: ShakingPatternProps) {
         transition={{ type: "timing", duration: 500, loop: true, repeatReverse: true }}
         style={{
           marginTop: 28,
-          backgroundColor: "rgba(0,0,0,0.45)",
+          backgroundColor: getStringToken("semantic.surface.experience.overlay"),
           borderWidth: 1,
           borderColor: `${accentColor}75`,
           borderRadius: 999,


### PR DESCRIPTION
## Summary
- MuteToggle: プラットフォーム依存の絵文字(🔔/🔕)をUnicode文字(♪/✕)に置換し、デザイントークンで着色
- Button: `iconElement` prop を追加してReactNodeベースのアイコン描画に対応
- IdleRitualPattern: ハードコードされた `rgba()` 6箇所をセマンティックトークンに統一
- ShakingPattern: ハードコードされた `rgba(0,0,0,0.45)` を `semantic.surface.experience.overlay` に統一

## 背景
PR #405 のデザインシステム監査で特定された高優先度項目の対応。Phase 5A（MuteToggle改善）と、最も影響範囲の大きいハードコード色の排除を実施。

## Test plan
- [x] `npx tsc --noEmit` 型チェックパス
- [x] ESLint パス
- [x] 全32テスト（MuteToggle/Button/IdleRitual/ShakingPattern/HistoryItemCard）パス
- [ ] Webブラウザでホーム画面・設定画面の見た目確認
- [ ] MuteToggleのON/OFF切り替え動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)