### PR TITLE
fix: pnpm-lock.yamlのspecifier乖離を修正

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,10 +31,10 @@ importers:
         specifier: 3.0.2
         version: 3.0.2(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       '@sentry/react-native':
-        specifier: ^8.11.1
+        specifier: ^8.7.0
         version: 8.11.1(@expo/env@2.0.11)(dotenv@16.4.7)(expo@54.0.33)(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       '@types/react-dom':
-        specifier: ^19.2.3
+        specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
       expo:
         specifier: ~54.0.33
@@ -82,13 +82,13 @@ importers:
         specifier: ^1.11.13
         version: 1.11.13
       i18next:
-        specifier: ^26.2.0
+        specifier: ^26.0.4
         version: 26.2.0(typescript@5.9.3)
       moti:
         specifier: ^0.30.0
         version: 0.30.0(react-dom@19.2.6(react@19.2.6))(react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       nativewind:
-        specifier: ^4.2.4
+        specifier: ^4.2.3
         version: 4.2.4(jmeizrpsp4mgnfdpmmwguwomfi)
       react:
         specifier: 19.2.6
@@ -97,22 +97,22 @@ importers:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
       react-i18next:
-        specifier: ^17.0.8
+        specifier: ^17.0.2
         version: 17.0.8(i18next@26.2.0(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react-native:
         specifier: 0.84.1
         version: 0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6)
       react-native-css-interop:
-        specifier: ^0.2.4
+        specifier: ^0.2.3
         version: 0.2.4(jmeizrpsp4mgnfdpmmwguwomfi)
       react-native-reanimated:
-        specifier: ~4.3.1
+        specifier: ~4.3.0
         version: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       react-native-safe-area-context:
         specifier: 5.8.0
         version: 5.8.0(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       react-native-screens:
-        specifier: ~4.25.1
+        specifier: ~4.25.0
         version: 4.25.1(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       react-native-view-shot:
         specifier: ^5.1.0
@@ -121,17 +121,17 @@ importers:
         specifier: ~0.21.2
         version: 0.21.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-native-worklets:
-        specifier: ^0.8.3
+        specifier: ^0.8.1
         version: 0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       react-native-worklets-core:
         specifier: ^1.6.3
         version: 1.6.3(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.60.0
+        specifier: ^1.59.1
         version: 1.60.0
       '@react-native-community/cli':
-        specifier: ^20.1.3
+        specifier: ^20.1.2
         version: 20.1.3(typescript@5.9.3)
       '@testing-library/jest-native':
         specifier: ^5.4.3
@@ -146,34 +146,34 @@ importers:
         specifier: ~19.2.14
         version: 19.2.14
       eas-cli:
-        specifier: ^18.13.1
+        specifier: ^18.7.0
         version: 18.13.1(@types/node@25.9.0)(typescript@5.9.3)
       eslint:
-        specifier: ^10.4.0
+        specifier: ^10.2.0
         version: 10.4.0(jiti@1.21.7)
       eslint-config-expo:
-        specifier: ^55.0.1
+        specifier: ^55.0.0
         version: 55.0.1(eslint@10.4.0(jiti@1.21.7))(typescript@5.9.3)
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@10.4.0(jiti@1.21.7))
       eslint-plugin-prettier:
-        specifier: ^5.5.5
+        specifier: ^5.5.4
         version: 5.5.5(eslint-config-prettier@10.1.8(eslint@10.4.0(jiti@1.21.7)))(eslint@10.4.0(jiti@1.21.7))(prettier@3.8.3)
       globals:
-        specifier: ^17.6.0
+        specifier: ^17.4.0
         version: 17.6.0
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@25.9.0)(ts-node@10.9.2(@types/node@25.9.0)(typescript@5.9.3))
       jest-expo:
-        specifier: ~55.0.17
+        specifier: ~55.0.14
         version: 55.0.17(@babel/core@7.29.0)(expo@54.0.33)(jest@29.7.0(@types/node@25.9.0)(ts-node@10.9.2(@types/node@25.9.0)(typescript@5.9.3)))(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       markdownlint-cli:
         specifier: ^0.48.0
         version: 0.48.0
       prettier:
-        specifier: ^3.8.3
+        specifier: ^3.8.1
         version: 3.8.3
       react-test-renderer:
         specifier: 19.2.6
@@ -6763,7 +6763,6 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -6987,11 +6986,6 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
-
-  yaml@2.8.3:
-    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -9081,9 +9075,9 @@ snapshots:
       node-stream-zip: 1.15.0
       ora: 5.4.1
       picocolors: 1.1.1
-      semver: 7.7.4
+      semver: 7.8.0
       wcwidth: 1.0.1
-      yaml: 2.8.3
+      yaml: 2.9.0
     transitivePeerDependencies:
       - typescript
 
@@ -9136,7 +9130,7 @@ snapshots:
       ora: 5.4.1
       picocolors: 1.1.1
       prompts: 2.4.2
-      semver: 7.7.4
+      semver: 7.8.0
 
   '@react-native-community/cli-types@20.1.3':
     dependencies:
@@ -9158,7 +9152,7 @@ snapshots:
       graceful-fs: 4.2.11
       picocolors: 1.1.1
       prompts: 2.4.2
-      semver: 7.7.4
+      semver: 7.8.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -9720,7 +9714,7 @@ snapshots:
 
   '@types/jsdom@20.0.1':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.0
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
@@ -12461,7 +12455,7 @@ snapshots:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 25.8.0
+      '@types/node': 25.9.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -13240,7 +13234,7 @@ snapshots:
 
   metro-runtime@0.83.3:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       flow-enums-runtime: 0.0.6
 
   metro-runtime@0.83.7:
@@ -15652,8 +15646,6 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
-
-  yaml@2.8.3: {}
 
   yaml@2.9.0: {}
 


### PR DESCRIPTION
## Summary
PR #420 (dependabot postcss) マージ時に pnpm-lock.yaml の内部 specifier 記録が package.json と乖離し、frozen-lockfile での CI が失敗していた問題を修正。

## Cause
dependabot がトランジティブ依存 (postcss) を更新した際、lockfile 内の独立 specifier (eslint, jest-expo, expo-router 等の minor version) も再ソルバで更新されたが、package.json への変更コミットが発生せず、両者が乖離した。

## Fix
\`pnpm install --lockfile-only\` で package.json を基準にロックファイルを再生成。

## Test plan
- [x] \`pnpm install --frozen-lockfile\` 成功