### PR TITLE
fix(e2e): Playwright webServer.timeout 拡大 + 初回手順を AGENTS.md に追記

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,8 @@ status: "active"
 | 全品質チェック（CI相当） | `pnpm ci:check`        |
 | スキル検証               | `pnpm validate:skills` |
 
+> E2E（Web）の初回実行時は `pnpm exec playwright install` でブラウザを取得しておく。`pnpm test:e2e:web` は内部で `pnpm build`（`expo export -p web`）→`serve` を起動するため、コールドビルドでは数分かかる（`playwright.config.ts` の `webServer.timeout` を 480 秒に設定）。
+
 ## 5. ワークフロー（AI-SDD / AI-TDD）
 
 - **計画先行**: 着手前にタスク計画をまとめ、小さな変更単位で進める。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ status: "active"
 | 全品質チェック（CI相当） | `pnpm ci:check`        |
 | スキル検証               | `pnpm validate:skills` |
 
-> E2E（Web）の初回実行時は `pnpm exec playwright install` でブラウザを取得しておく。`pnpm test:e2e:web` は内部で `pnpm build`（`expo export -p web`）→`serve` を起動するため、コールドビルドでは数分かかる（`playwright.config.ts` の `webServer.timeout` を 480 秒に設定）。
+> E2E（Web）の初回実行時は `pnpm exec playwright install` でブラウザを取得しておく。`pnpm test:e2e:web` は内部で `pnpm build`（`expo export -p web`）→`pnpm exec serve` を起動するため、コールドビルドでは数分かかる（詳細は `playwright.config.ts` の `webServer.timeout` 設定を参照）。
 
 ## 5. ワークフロー（AI-SDD / AI-TDD）
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,6 +32,6 @@ export default defineConfig({
     command: `pnpm build && pnpm exec serve -s dist -p ${process.env.PLAYWRIGHT_WEB_PORT ?? 3000}`,
     url: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
-    timeout: 240 * 1000,
+    timeout: 480 * 1000,
   },
 });


### PR DESCRIPTION
## 目的

ローカル開発者が初回 `pnpm test:e2e:web` を実行する際の DX を改善する。今回の E2E 機能検証で以下の 2 点に当たったため、再発防止策を入れる（機能バグは E2E 全 pass で未検出）。

## 変更点

- `playwright.config.ts`: `webServer.timeout` を **240 秒 → 480 秒** に拡大
  - `pnpm build`（`expo export -p web`）→ `pnpm exec serve` のコールドビルドが 240 秒で間に合わずタイムアウトする実例を確認
  - CI でも `actions/cache` ミス時のセーフティとして有効
- `AGENTS.md` §4 主要コマンド一覧の直下に E2E 初回手順注記を追加
  - `pnpm exec playwright install` でブラウザを取得する手順
  - コールドビルドで数分かかる旨と `webServer.timeout` の値

## テスト結果ログ

ローカルで Playwright 全 pass を確認（修正前の値で実行、修正自体は閾値拡大のみで実行内容は変えない）。

```
Running 15 tests using 5 workers
  ✓ chromium × 5 (3.4s ~ 10.8s)
  ✓ Mobile Chrome × 5 (688ms ~ 8.8s)
  ✓ Mobile Safari × 5 (3.4s ~ 10.8s)

  15 passed (36.0s)
```

## 影響範囲

- `.github/workflows/e2e-web.yml` の Playwright 実行に影響（タイムアウト緩和のみ）
- ローカル開発者の初回セットアップガイドが明確化
- 既存テストロジック・アプリ実装には変更なし

## 関連

- v1.5.1 で残っていた E2E ローカル DX 課題のフォローアップ