### PR TITLE
release: v1.5.2 — E2E ローカル DX 改善（Playwright timeout / AGENTS.md 初回手順）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,8 @@ status: "active"
 | 全品質チェック（CI相当） | `pnpm ci:check`        |
 | スキル検証               | `pnpm validate:skills` |
 
+> E2E（Web）の初回実行時は `pnpm exec playwright install` でブラウザを取得しておく。`pnpm test:e2e:web` は内部で `pnpm build`（`expo export -p web`）→`pnpm exec serve` を起動するため、コールドビルドでは数分かかる（詳細は `playwright.config.ts` の `webServer.timeout` 設定を参照）。
+
 ## 5. ワークフロー（AI-SDD / AI-TDD）
 
 - **計画先行**: 着手前にタスク計画をまとめ、小さな変更単位で進める。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ status: "active"
 | 全品質チェック（CI相当） | `pnpm ci:check`        |
 | スキル検証               | `pnpm validate:skills` |
 
-> E2E（Web）の初回実行時は `pnpm exec playwright install` でブラウザを取得しておく。`pnpm test:e2e:web` は内部で `pnpm build`（`expo export -p web`）→`pnpm exec serve` を起動するため、コールドビルドでは数分かかる（詳細は `playwright.config.ts` の `webServer.timeout` 設定を参照）。
+> E2E（Web）の初回実行時は `pnpm exec playwright install` でブラウザを取得しておく。`pnpm test:e2e:web` は内部で `pnpm build` → `pnpm exec serve` を起動するため、コールドビルドでは数分かかる（詳細は `playwright.config.ts` の `webServer.timeout` 設定を参照）。
 
 ## 5. ワークフロー（AI-SDD / AI-TDD）
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,6 +32,6 @@ export default defineConfig({
     command: `pnpm build && pnpm exec serve -s dist -p ${process.env.PLAYWRIGHT_WEB_PORT ?? 3000}`,
     url: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
-    timeout: 240 * 1000,
+    timeout: 480 * 1000,
   },
 });


### PR DESCRIPTION
## Summary

v1.5.1 直後のローカル DX フォローアップ。E2E（Playwright Web）の初回実行で発生するつまずきを構造的に解消。

## Changes since v1.5.1

- #423: Playwright `webServer.timeout` 240→480 秒（コールドビルド対応） + AGENTS.md §4 直下に E2E 初回手順（`pnpm exec playwright install` / コールドビルド注意）を追記

## Verification

- ✅ ローカル Playwright 全 pass: `chromium / Mobile Chrome / Mobile Safari × 5 specs = 15/15` (36.0s)
- ✅ PR #423 CI: AI Code Review / CodeQL × 4 / Playwright Tests 全 pass
- ✅ Gemini Review 指摘（SSOT 違反 / 表記揺れ）対応・thread resolve 済み
- ✅ アプリ実装・テストロジックには変更なし（閾値拡大 + ドキュメント追記のみ）

## Test plan

- [x] ローカル E2E (Playwright): 15/15 pass
- [x] CI: 全 required check pass
- [x] 機能影響なし（タイムアウト緩和とドキュメント追記のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)