### PR TITLE
docs(agents): expo export 詳細記述を削除（Gemini SSOT指摘反映）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ status: "active"
 | 全品質チェック（CI相当） | `pnpm ci:check`        |
 | スキル検証               | `pnpm validate:skills` |
 
-> E2E（Web）の初回実行時は `pnpm exec playwright install` でブラウザを取得しておく。`pnpm test:e2e:web` は内部で `pnpm build`（`expo export -p web`）→`pnpm exec serve` を起動するため、コールドビルドでは数分かかる（詳細は `playwright.config.ts` の `webServer.timeout` 設定を参照）。
+> E2E（Web）の初回実行時は `pnpm exec playwright install` でブラウザを取得しておく。`pnpm test:e2e:web` は内部で `pnpm build` → `pnpm exec serve` を起動するため、コールドビルドでは数分かかる（詳細は `playwright.config.ts` の `webServer.timeout` 設定を参照）。
 
 ## 5. ワークフロー（AI-SDD / AI-TDD）
 


### PR DESCRIPTION
## 目的

PR #424 (release v1.5.2) で Gemini Code Assist が指摘した SSOT 違反を release 前に解消。

## 変更点

- `AGENTS.md` §4 直下の E2E 注記から `（expo export -p web）` の実装詳細を削除
- `pnpm build` のスクリプト中身は `package.json` 側を SSOT として参照する形に統一

## 影響範囲

ドキュメント表記のみ。コード・テスト・CI に影響なし。

## 関連

- PR #424 (release v1.5.2) を block しているレビュー指摘の解消