### PR TITLE
docs(android): Google Play 申請情報を整備（Data safety/Content rating/Closed testing）

### DIFF
--- a/docs/goals/android-release-readiness.md
+++ b/docs/goals/android-release-readiness.md
@@ -27,7 +27,7 @@ Android版デジタルおみくじを **Google Play に申請可能な状態** �
 - [x] Google Play Console 申請に必要な情報が docs 化されている（[../project/google-play-submission.md](../project/google-play-submission.md)、2026-06-07）
 - [x] Privacy Policy / Data safety / Content rating の方針が整理されている（Sentry 有効前提の Data safety 申告、全年齢レーティング方針、2026-06-07）
 - [x] ストア掲載文・スクリーンショット・Feature Graphic の準備項目が整理されている（画像アセットは未作成だが要件・推奨カットを docs 化、2026-06-07）
-- [x] Closed testing の進め方が整理されている（internal→closed(12人×14日)→production、2026-06-07）
+- [x] Closed testing の進め方が整理されている（internal→closed(20人×14日)→production、2026-06-07）
 - [x] README に Android 公開準備手順が反映されている（2026-06-06）
 
 ### 品質ゲート（すべて成功）

--- a/docs/goals/android-release-readiness.md
+++ b/docs/goals/android-release-readiness.md
@@ -20,14 +20,14 @@ Android版デジタルおみくじを **Google Play に申請可能な状態** �
 - [x] Expo設定が整理されている（app.config.ts / app.json の不整合解消、2026-06-06）
 - [x] Android package名が確定（`com.s977043.digitalomikuji`）し、全設定で一致（2026-06-06）
 - [ ] production AAB が生成できる
-- [ ] EAS Build / Submit 設定が確認されている（`eas.json`）
+- [x] EAS Build / Submit 設定が確認されている（`eas.json`：production=AAB/autoIncrement、submit track=internal、2026-06-07）
 
 ### Google Play 申請情報
 
-- [ ] Google Play Console 申請に必要な情報が docs 化されている
-- [ ] Privacy Policy / Data safety / Content rating の方針が整理されている
-- [ ] ストア掲載文・スクリーンショット・Feature Graphic の準備項目が整理されている
-- [ ] Closed testing の進め方が整理されている
+- [x] Google Play Console 申請に必要な情報が docs 化されている（[../project/google-play-submission.md](../project/google-play-submission.md)、2026-06-07）
+- [x] Privacy Policy / Data safety / Content rating の方針が整理されている（Sentry 有効前提の Data safety 申告、全年齢レーティング方針、2026-06-07）
+- [x] ストア掲載文・スクリーンショット・Feature Graphic の準備項目が整理されている（画像アセットは未作成だが要件・推奨カットを docs 化、2026-06-07）
+- [x] Closed testing の進め方が整理されている（internal→closed(12人×14日)→production、2026-06-07）
 - [x] README に Android 公開準備手順が反映されている（2026-06-06）
 
 ### 品質ゲート（すべて成功）

--- a/docs/project/google-play-submission.md
+++ b/docs/project/google-play-submission.md
@@ -27,19 +27,22 @@
 
 ### Data safety フォーム回答（推奨）
 
-「アプリはユーザーデータを収集または共有しますか？」→ **はい**。収集するデータタイプは以下の2つ。
+「アプリはユーザーデータを収集または共有しますか？」→ **はい**。収集するデータタイプは以下の3つ。
 
 - **App activity > Crash logs**
   - 収集: はい / 共有: いいえ（後述）/ 目的: アプリの機能・分析（品質改善）
 - **App info and performance > Diagnostics**
   - 収集: はい / 共有: いいえ（後述）/ 目的: アプリの機能・分析
+- **Device or other IDs**
+  - 収集: はい / 共有: いいえ（後述）/ 目的: アプリの機能・分析
+  - Sentry SDK はクラッシュ影響ユーザー数を識別するためインストールID（デバイスID）を自動生成・送信するため、Google Play 基準では本カテゴリの収集に該当する。差し戻しリスク低減のため**最初から収集ありで申告**する。
 
 補足事項:
 
 - **「共有(sharing)」の扱い**: Google Play の定義では、サービスプロバイダ（処理委託先=processor）への転送は「共有」に該当しない。Sentry は処理委託先のため「収集: はい / 共有: いいえ」で申告する（自社管理下でのエラー解析に限定、第三者への販売・独立利用なし）。
 - **転送時の暗号化**: はい（HTTPS）。
 - **データ削除のリクエスト手段**: Privacy Policy に問い合わせ窓口を記載し、Sentry 側のデータ保持期間（既定 約90日で自動失効）を明記する。
-- **Device or other IDs**: Sentry SDK がインストール識別子を生成し得る。`sendDefaultPii: false` で PII は送らないが、安全側で「収集する可能性」を確認しておくこと。→ TODO: 本番 DSN 設定後に Sentry ダッシュボードの実送信データで1回確認。
+- **Device or other IDs の確定**: 上記のとおり Sentry はインストールID を送信するため収集ありで申告する。`sendDefaultPii: false` で IP/UA 等の PII は送らない。本番 DSN 設定後に Sentry ダッシュボードの実送信データで最終確認すること。
 
 ### ストア文との整合（要対応）
 
@@ -81,7 +84,7 @@ IARC 質問票への回答方針:
 
 - `app.json`: `icon: ./assets/icon.png` / `splash`（背景 `#dc2626`）/ `android.adaptiveIcon`（foreground `./assets/adaptive-icon.png`、背景 `#dc2626`）。
 - アセット存在: `icon.png` / `adaptive-icon.png` / `splash.png` / `favicon.png`。
-- 確認項目: **アダプティブアイコンのセーフゾーン**（foreground の重要要素が中央 66% に収まるか）。`icon.png` と `adaptive-icon.png` が同一バイトサイズのため、アダプティブ用に余白を考慮した別書き出しが望ましいか確認。
+- **要対応（アダプティブアイコン）**: `adaptive-icon.png` は **背景を完全に透過（アルファチャンネルあり）** にし、ロゴ等の主要要素のみを中央 66% のセーフゾーンに収めた画像として `icon.png` とは**別に書き出す**こと。foreground に背景色が含まれると、ランチャー形状（丸/角丸）のマスク処理で背景が二重表示・端が不自然にカットされる。現状は両者が同一バイトサイズのため要差し替え。
 
 ## 5. 署名 / target API level
 
@@ -91,10 +94,10 @@ IARC 質問票への回答方針:
 
 ## 6. Closed testing の進め方
 
-> Google Play の新規デベロッパー（個人）アカウントは、**Production 申請前に Closed testing が必須**（テスター12人以上 × 14日間継続）。
+> Google Play の新規デベロッパー（個人）アカウント（2023-11-13 以降に作成）は、**Production 申請前に Closed testing が必須**（テスター **20人以上** が **14日間連続**でオプトイン）。20人未満では Production access に進めない。
 
 1. **Internal testing**: AAB を internal track にアップロード（`eas.json` の submit.production.android.track = `internal`）。自分・少人数で動作確認。
-2. **Closed testing**: テスター（12人以上）を招待し、**14日間継続**で利用してもらう。フィードバック収集。
+2. **Closed testing**: テスター（**20人以上**）を招待し、**14日間連続**でオプトイン・利用してもらう。フィードバック収集。
 3. **Production access 申請**: 上記を満たすと production 申請が可能になる。
 4. 申請内容: Data safety / Content rating / ストア掲載 / 対象国・年齢 を入力し審査提出。
 
@@ -114,5 +117,5 @@ EAS 認証が必要なため、以下のいずれかで実行（詳細は goal d
 - [ ] スクリーンショット2枚以上 + Feature Graphic を作成・アップロード
 - [ ] アプリアイコン 512×512 をアップロード
 - [ ] Privacy Policy URL を設定
-- [ ] internal → closed testing（12人×14日）→ production access
+- [ ] internal → closed testing（20人×14日）→ production access
 - [ ] ストア文に Sentry 診断データの注記を反映（本書 §1）

--- a/docs/project/google-play-submission.md
+++ b/docs/project/google-play-submission.md
@@ -1,0 +1,118 @@
+# Google Play 申請情報（デジタルおみくじ）
+
+> ステータス: draft / 最終更新: 2026-06-07
+> 関連: [release_metadata.md](./release_metadata.md)（ストア掲載文）/ [../goals/android-release-readiness.md](../goals/android-release-readiness.md)（ゴール・DoD）/ `eas.json` / `app.json`
+> 本書は Google Play Console 申請時に入力する情報の SSOT。ストア掲載文（タイトル/説明/キーワード）は `release_metadata.md` を参照。
+
+## 0. 申請前提（確定事項）
+
+- アプリ名（本番）: デジタルおみくじ / Digital Omikuji
+- package 名: `com.s977043.digitalomikuji`（**公開後変更不可**）
+- カテゴリ: エンターテイメント（Entertainment）
+- 課金 / 広告: なし
+- Privacy Policy URL: `https://digital-omikuji.vercel.app/privacy-policy`
+- AAB 生成: EAS（`eas build --profile production --platform android`、app-bundle）
+- 提出 track（初期）: internal → closed testing → production
+
+## 1. Data safety（データセーフティ）
+
+> 本アプリは **本番で Sentry を有効化する**（`EXPO_PUBLIC_SENTRY_DSN` を本番に設定）方針。これに基づく申告。
+
+### 収集・送信の実態
+
+- **アプリ自体は個人情報を収集しない**: ログイン無し / 独自バックエンドへの送信無し。
+- **おみくじ履歴・アプリ設定**: `AsyncStorage` で**端末内ローカル保存のみ**。外部送信なし → Data safety の「収集」非該当。
+- **Sentry（エラートラッキング）**: クラッシュ/例外発生時に、診断データ（スタックトレース、OS/アプリバージョン、デバイス機種等）を Sentry に送信。
+  - プライバシー保護実装: `sendDefaultPii: false`（IP/User-Agent/URL を送らない）、`beforeSend` で `user`/`request` を消去、console breadcrumb を抑制（履歴ID・運勢値の漏洩防止）。
+
+### Data safety フォーム回答（推奨）
+
+「アプリはユーザーデータを収集または共有しますか？」→ **はい**。収集するデータタイプは以下の2つ。
+
+- **App activity > Crash logs**
+  - 収集: はい / 共有: いいえ（後述）/ 目的: アプリの機能・分析（品質改善）
+- **App info and performance > Diagnostics**
+  - 収集: はい / 共有: いいえ（後述）/ 目的: アプリの機能・分析
+
+補足事項:
+
+- **「共有(sharing)」の扱い**: Google Play の定義では、サービスプロバイダ（処理委託先=processor）への転送は「共有」に該当しない。Sentry は処理委託先のため「収集: はい / 共有: いいえ」で申告する（自社管理下でのエラー解析に限定、第三者への販売・独立利用なし）。
+- **転送時の暗号化**: はい（HTTPS）。
+- **データ削除のリクエスト手段**: Privacy Policy に問い合わせ窓口を記載し、Sentry 側のデータ保持期間（既定 約90日で自動失効）を明記する。
+- **Device or other IDs**: Sentry SDK がインストール識別子を生成し得る。`sendDefaultPii: false` で PII は送らないが、安全側で「収集する可能性」を確認しておくこと。→ TODO: 本番 DSN 設定後に Sentry ダッシュボードの実送信データで1回確認。
+
+### ストア文との整合（要対応）
+
+`release_metadata.md` の「個人情報は収集しません」は **PII を収集しない**意味では正しい（Sentry も PII 排除）。ただし誤解回避のため、以下の補足を推奨。
+
+> 個人を特定する情報は収集しません。アプリの品質向上のため、匿名のクラッシュ/診断データを利用する場合があります（個人の特定はできません）。
+
+## 2. Content rating（コンテンツレーティング / IARC 質問票）
+
+IARC 質問票への回答方針:
+
+- 暴力: なし
+- 性的表現: なし
+- 不適切な言葉: なし
+- 規制対象物（酒/薬物等）: なし
+- **ギャンブル / 賭博: なし** — **重要**: おみくじは娯楽。賭け金・報酬・課金ガチャ無し。simulated gambling にも非該当。
+- ユーザー間交流: なし（SNS機能・チャット無し）
+- 位置情報の共有: なし
+
+想定レーティング: **全年齢**（IARC 3+ / ESRB Everyone / PEGI 3）。
+
+注意: 「おみくじ＝占い/fortune」を *simulated gambling* と誤認されないよう、申請時の説明で**賭博・実課金要素が無いこと**を明確にする。
+
+## 3. ストア掲載アセット
+
+### テキスト（[release_metadata.md](./release_metadata.md) を参照・整備済み）
+
+- アプリ名 / 短い説明（80字以内）/ 詳細説明（4000字以内）/ キーワード — 日英あり。
+
+### 画像（**未準備・要作成**）
+
+- アプリアイコン: 512×512 PNG（32bit, アルファ可）— `assets/icon.png` から書き出し。
+- Feature Graphic: 1024×500 PNG/JPG — **未作成**。
+- スマホ スクリーンショット: 2〜8枚、JPEG/24bit PNG、各辺 320〜3840px、縦推奨 — **未撮影**。
+- タブレット（7インチ/10インチ）: 任意。
+- スクリーンショット推奨カット: ①ホーム（振る前）②振る演出 ③結果表示 ④履歴画面（4枚程度で機能を網羅）。
+
+## 4. アイコン / スプラッシュ（設定は確定済み）
+
+- `app.json`: `icon: ./assets/icon.png` / `splash`（背景 `#dc2626`）/ `android.adaptiveIcon`（foreground `./assets/adaptive-icon.png`、背景 `#dc2626`）。
+- アセット存在: `icon.png` / `adaptive-icon.png` / `splash.png` / `favicon.png`。
+- 確認項目: **アダプティブアイコンのセーフゾーン**（foreground の重要要素が中央 66% に収まるか）。`icon.png` と `adaptive-icon.png` が同一バイトサイズのため、アダプティブ用に余白を考慮した別書き出しが望ましいか確認。
+
+## 5. 署名 / target API level
+
+- **署名**: Google Play App Signing を利用（推奨）。EAS が upload key を管理し、`eas build` が署名済み AAB を生成。Play Console 側で App Signing を有効化。
+- **target API level**: Google Play は新規アプリに targetSdkVersion 35（Android 15）以上を要求（2025年要件）。Expo SDK54 は targetSdk 35 相当 → 充足見込み。AAB アップロード時に警告が無いことを確認。
+- **versionCode / versionName**: `eas.json` の production は `autoIncrement: true`（versionCode 自動採番）、`appVersionSource: "remote"`（EAS 側で管理）。versionName は `app.json` の `version`。
+
+## 6. Closed testing の進め方
+
+> Google Play の新規デベロッパー（個人）アカウントは、**Production 申請前に Closed testing が必須**（テスター12人以上 × 14日間継続）。
+
+1. **Internal testing**: AAB を internal track にアップロード（`eas.json` の submit.production.android.track = `internal`）。自分・少人数で動作確認。
+2. **Closed testing**: テスター（12人以上）を招待し、**14日間継続**で利用してもらう。フィードバック収集。
+3. **Production access 申請**: 上記を満たすと production 申請が可能になる。
+4. 申請内容: Data safety / Content rating / ストア掲載 / 対象国・年齢 を入力し審査提出。
+
+## 7. production AAB ビルド（最終ゲート / ユーザー作業）
+
+EAS 認証が必要なため、以下のいずれかで実行（詳細は goal doc 参照）。
+
+- **推奨**: GitHub Secrets に `EXPO_TOKEN` を登録 → Actions の「EAS Build (Android)」を `workflow_dispatch`（profile=production）で実行。
+- 本番で Sentry を有効化するため、ビルド環境に `EXPO_PUBLIC_SENTRY_DSN`（本番 DSN）を設定すること。
+
+## 8. 申請前 最終チェックリスト
+
+- [ ] `EXPO_PUBLIC_SENTRY_DSN`（本番）をビルド環境に設定
+- [ ] production AAB を生成（EAS）
+- [ ] Data safety フォーム入力（本書 §1 に従う）
+- [ ] Content rating 質問票（本書 §2 に従う）
+- [ ] スクリーンショット2枚以上 + Feature Graphic を作成・アップロード
+- [ ] アプリアイコン 512×512 をアップロード
+- [ ] Privacy Policy URL を設定
+- [ ] internal → closed testing（12人×14日）→ production access
+- [ ] ストア文に Sentry 診断データの注記を反映（本書 §1）


### PR DESCRIPTION
## 概要

Android Google Play 申請準備マイルストーンの DoD「Google Play 申請情報の docs 化」を完了する。`docs/project/google-play-submission.md` を新規作成し、申請に必要な情報を SSOT として整理。

## 背景

PR #440 で設定統合・expo-doctor 18/18 が完了。残る申請情報（Data safety / Content rating / アセット要件 / Closed testing 手順）が未 docs 化だったため整備する。

## 変更内容

### `docs/project/google-play-submission.md`（新規）

- **Data safety**: 本番で Sentry を有効化する前提（ユーザー判断で確定）の申告方針。
  - `Crash logs` / `Diagnostics` を「収集: はい / 共有: いいえ」で申告（Sentry は processor のため Google 定義上 sharing 非該当）。
  - PII 排除実装（`sendDefaultPii:false`、`beforeSend` で user/request 消去、console breadcrumb 抑制）と、履歴/設定の AsyncStorage ローカル保存（収集非該当）を明記。
  - **要対応**: ストア文「個人情報は収集しません」への注記追加を提案。
  - **TODO**: `Device or other IDs` は本番 DSN 設定後に Sentry 実データで要確認。
- **Content rating**: 娯楽・賭博/課金/広告なし → 全年齢（IARC 3+）。おみくじが simulated gambling と誤認されない注意を記載。
- **ストア掲載アセット**: アイコン 512 / Feature Graphic 1024×500 / スクショ要件と推奨カット（未作成項目を明示）。
- **署名 / target API level**: Google Play App Signing、targetSdk 35 要件、versionCode 自動採番方針。
- **Closed testing**: internal → closed(12人×14日) → production access の手順。
- **申請前 最終チェックリスト**。

### `docs/goals/android-release-readiness.md`（DoD 更新）

- Google Play 申請情報の 4 項目 + `eas.json` 確認をチェック済みに更新。

## 検証

- `markdownlint docs/project/google-play-submission.md docs/goals/android-release-readiness.md` → エラーなし。
- ドキュメントのみの変更（コード非変更）。

## 残ゲート（本 PR 対象外・ユーザー作業）

- `EXPO_TOKEN` 登録 → production AAB ビルド（EAS 認証要）
- 画像アセット作成（スクショ / Feature Graphic）
- Data safety / ストア文の最終確定はユーザーの法的申告事項

## レビュー観点（本来 Codex 相談予定だったが usage limit のため未実施）

- Data safety の processor 扱い（Sentry を「共有: いいえ」とする判断）の妥当性
- Content rating 全年齢区分の妥当性

🤖 Generated with [Claude Code](https://claude.com/claude-code)