### PR TITLE
fix(sentry): Sentry を正しい org/project で再有効化

### DIFF
--- a/app.json
+++ b/app.json
@@ -41,7 +41,15 @@
           "backgroundColor": "#dc2626"
         }
       ],
-      "./plugins/withWorklets"
+      "./plugins/withWorklets",
+      [
+        "@sentry/react-native/expo",
+        {
+          "organization": "3396cc",
+          "project": "digital-omikuji",
+          "url": "https://sentry.io/"
+        }
+      ]
     ],
     "extra": {
       "eas": {

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,9 +1,9 @@
-const { getDefaultConfig } = require("expo/metro-config");
+const { getSentryExpoConfig } = require("@sentry/react-native/metro");
 const { withNativeWind } = require("nativewind/metro");
 const path = require("path");
 
-// Sentry は一旦外しているため標準の Expo Metro config を使う。
-const config = getDefaultConfig(__dirname);
+// Sentry の Expo Metro config をベースに使い、正しい sourcemap を生成する。
+const config = getSentryExpoConfig(__dirname);
 
 // Web bundle から不要な native-only runtime を除外する。
 // - react-native-reanimated: MotionView.web.tsx が CSS アニメーションを使う


### PR DESCRIPTION
## 概要
production ビルドから一旦外していた Sentry を**正しい org/project slug** で再有効化する。

## 背景（「Project not found」の真因）
EAS の Sentry sourcemap upload が `Project not found` で失敗していたのは app.json の org/project が誤っていたため: organization `mine-take`→**`3396cc`** / project `digital-omikuji`(存在せず)→**`digital-omikuji`**(新規作成)。Sentry の実 org slug は `3396cc`。`SENTRY_AUTH_TOKEN` は EAS 登録済み。

## 変更
- `app.json`: `@sentry/react-native/expo` plugin を org=`3396cc` / project=`digital-omikuji` で復元
- `metro.config.js`: `getSentryExpoConfig` に戻す

## 検証
- ✅ tsc / lint / test(45 suites 311) green
- ✅ **EAS production ビルド成功**（sourcemap upload 完了 + AAB 生成、`Project not found` 解消）

## 残作業
- `EXPO_PUBLIC_SENTRY_DSN` を新 project DSN に更新（runtime 用）
- Data safety を「収集あり」前提に戻す

🤖 Generated with [Claude Code](https://claude.com/claude-code)