### PR TITLE
chore(process): 振り返り改善 — CI ガード3件 + 教訓明文化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ on:
       - "metro.config.js"
       - "tailwind.config.js"
       - ".github/workflows/ci.yml"
+      - ".gitignore"
+      - "app.json"
+      - "app.config.ts"
+      - "eas.json"
+      - "design-system/**"
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [main, develop]
@@ -44,6 +49,11 @@ on:
       - "metro.config.js"
       - "tailwind.config.js"
       - ".github/workflows/ci.yml"
+      - ".gitignore"
+      - "app.json"
+      - "app.config.ts"
+      - "eas.json"
+      - "design-system/**"
   workflow_dispatch:
 
 concurrency:
@@ -51,6 +61,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  guards:
+    name: Repo Guards
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      # tracked なのに .gitignore にマッチするファイルは、git-archive を使う
+      # 消費者（EAS Build 等）がアップロードから除外し、実行時/ビルド時に
+      # 「module not found」で落ちる。pr*.json が primitive.json を glob 誤マッチ
+      # した #443 の再発防止。
+      - name: .gitignore does not drop tracked files
+        run: |
+          matched=$(git ls-files | git check-ignore --stdin --verbose || true)
+          if [ -n "$matched" ]; then
+            echo "::error::These tracked files are matched by .gitignore (git-archive / EAS consumers will drop them):"
+            echo "$matched"
+            exit 1
+          fi
+          echo "OK: no tracked file is ignored by .gitignore"
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
+      # SDK と react-native 等の不整合（dependabot が SDK 範囲外へ上げる等）を検出
+      - name: expo-doctor (SDK integrity)
+        run: npx expo-doctor
+
+      # codegen / require 解決の失敗を EAS ビルド前にローカル相当で検出
+      - name: Production JS bundle (codegen / require check)
+        run: APP_VARIANT=production npx expo export --platform android --no-bytecode --output-dir /tmp/ci-export
+
   ci:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,7 +369,7 @@ git add river-reviewer && git commit -m "chore: update river-reviewer"
 - `docs/design/design_guidelines.md`: ムード・配色・余白などの実装補助ガイド（実装ベースのデザイン判断SSOT）
 - スクリーンショットやビルド成果物は必要に応じてPRに添付する。
 
-## 13. ハマりどころ（再発防止メモ）
+## 15. ハマりどころ（再発防止メモ）
 
 SDK56 移行（#443）と Sentry 再有効化（#450）で踏んだ落とし穴。機械検出できるものは CI の `Repo Guards` job（`.github/workflows/ci.yml`）でガード済み。
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,8 @@ dependabot PR が複数滞留している場合、**1件ずつ手動マージし
 | 既存ブランチ割当 | `git worktree add .worktrees/<task-slug> <branch>`                                            |
 | 使い捨て検証     | ブランチ無しのdetached Worktreeも可                                                           |
 
+> **並行セッション注意**: 別の Claude セッションが動く可能性がある時は独立 worktree（`/tmp` 等）を使い、同一 worktree を共有しない。共有すると未コミット変更消失・ブランチ切替の競合が起きる。ファイル操作のみなら GitHub API（push_files）で worktree 非依存に行う。
+
 ### クリーンアップ
 
 - タスク完了後はWorktreeを削除する
@@ -366,3 +368,13 @@ git add river-reviewer && git commit -m "chore: update river-reviewer"
 - `docs/design-system/`: token/component契約のSSOT
 - `docs/design/design_guidelines.md`: ムード・配色・余白などの実装補助ガイド（実装ベースのデザイン判断SSOT）
 - スクリーンショットやビルド成果物は必要に応じてPRに添付する。
+
+## 13. ハマりどころ（再発防止メモ）
+
+SDK56 移行（#443）と Sentry 再有効化（#450）で踏んだ落とし穴。機械検出できるものは CI の `Repo Guards` job（`.github/workflows/ci.yml`）でガード済み。
+
+- **Expo SDK と react-native のバージョン対応**: RN は Expo SDK に紐づく（SDK54=RN0.81 / SDK55=0.83 / SDK56=0.85）。dependabot が RN を SDK 範囲外へ上げると「宙ぶらりん」状態になり EAS の codegen（VirtualView 等）が失敗する。`npx expo-doctor`（CI で実行）で整合を確認。
+- **`.gitignore` の glob が tracked file を巻き込む**: `pr*.json` が `primitive.json` を誤マッチし、git tracked でも EAS（git-archive は `.gitignore` を尊重）がアップロードから除外して Bundle 失敗。`git check-ignore -v <file>`（CI で検出）で確認。**ビルド依存データは `docs/` でなくアプリソース内に置く**（token JSON は `design-system/tokens/*.json`）。
+- **並行セッションとの worktree 競合**: 別セッションが同一 worktree を使うと未コミット変更が消失・ブランチが切り替わる。並行時は独立 worktree（`/tmp` 等）。ファイル操作のみなら GitHub API（push_files）で worktree 非依存に。
+- **Sentry の org/project slug**: Sentry の org slug は **Expo アカウント名とは別物**（例: Expo `mine-take` ↔ Sentry org `3396cc`）。`app.json` の `@sentry/react-native/expo` plugin には Sentry Settings の実 slug を設定する。誤ると EAS の sourcemap upload が「Project not found」で失敗。URL `https://<org-slug>.sentry.io/` で確認可能。`@sentry/react-native` は SDK56 では `~7.11.0` で `getSentryExpoConfig` / expo plugin が動く（v8 不要）。
+- **EAS ビルド失敗は入れ子になりうる**: 1つ解くと次のフェーズで別の失敗が露呈する。`expo export`（CI で実行）で JS バンドル段階を前倒し検証し、native/Sentry 段階は expo.dev のフェーズ別ログで切り分ける。


### PR DESCRIPTION
## Summary
直前セッション（#436 jest preset / #440 Expo設定 / #442 申請docs / #443 SDK56移行 / #450 Sentry再有効化）の振り返りから、再発防止策を実装。

### B. 自動ガード（`.github/workflows/ci.yml` の Repo Guards job）
- **gitignore 矛盾検出**: `git ls-files \| git check-ignore --stdin` で tracked かつ .gitignore にマッチするファイルを検出して fail。`pr*.json` が `primitive.json` を glob 誤マッチし EAS Bundle が失敗した **#443 の真因**を機械的に防ぐ。
- **expo-doctor**: SDK と react-native 等の不整合（dependabot が SDK 範囲外へ上げる）を検出。
- **expo export(production)**: codegen / require 解決の失敗を EAS ビルド前にローカル相当で検出。
- paths に `.gitignore` / `app.json` / `app.config.ts` / `eas.json` / `design-system/**` を追加。

### A. ドキュメント追記（`AGENTS.md`）
- 「## 13. ハマりどころ（再発防止メモ）」: SDK×RN バージョン対応、gitignore glob 誤マッチ、worktree 競合、**Sentry org slug は Expo 名と別物**、EAS 失敗の入れ子構造。
- Worktree運用規約に「並行セッション注意」（独立 worktree / GitHub API での非干渉操作）。

## Test plan
- [x] gitignore guard dry-run: `NONE`（false positive なし）
- [x] `markdownlint` / `actionlint` green

## 関連セッション
- 前回の振り返り PR: なし（**初回**）
- 対象 PR: #436, #440, #442, #443, #450
- 発生したインシデント: EAS production ビルド **5回失敗→成功**（4層の入れ子障害）、並行セッションとの worktree 競合 複数回

🤖 Generated with [Claude Code](https://claude.com/claude-code)