### PR TITLE
fix(sound,motion): River レビュー指摘3件の対応

### DIFF
--- a/components/design-system/MotionView.native.tsx
+++ b/components/design-system/MotionView.native.tsx
@@ -71,6 +71,21 @@ function toNum(v: number | string): number {
   return Number.isNaN(n) ? 0 : n;
 }
 
+// オブジェクトのキー順序に依存しない JSON 文字列化。animate/from が動的生成されても
+// 同一内容なら同一キーになり、過剰な再アニメーションを防ぐ。
+function stableStringify(obj: unknown): string {
+  return JSON.stringify(obj, (_key, value) =>
+    value && typeof value === "object" && !Array.isArray(value)
+      ? Object.keys(value as Record<string, unknown>)
+          .sort()
+          .reduce<Record<string, unknown>>((acc, k) => {
+            acc[k] = (value as Record<string, unknown>)[k];
+            return acc;
+          }, {})
+      : value
+  );
+}
+
 function getRaw(d: AnimDict | undefined, key: AnimKey): AnimValue | undefined {
   if (!d) return undefined;
   if (key === "rotate") return d.rotateZ ?? d.rotate;
@@ -114,7 +129,8 @@ export const MotionView = forwardRef<View, MotionViewProps>(function MotionView(
   };
 
   // animate / transition の差分でのみ再アニメーション。
-  const animKey = JSON.stringify({ animate, from, duration, delay, loop, repeatReverse });
+  // animate/from が動的生成されてもキー順序に依存しないよう安定化する。
+  const animKey = stableStringify({ animate, from, duration, delay, loop, repeatReverse });
 
   useEffect(() => {
     for (const key of ANIM_KEYS) {

--- a/utils/SoundManager.ts
+++ b/utils/SoundManager.ts
@@ -9,6 +9,7 @@ import { reportSilentError } from "./errorReporter";
 class SoundManager {
   private sounds: Map<string, AudioPlayer> = new Map();
   private sources: Map<string, AudioSource> = new Map();
+  private loading: Set<string> = new Set();
   private isReady: boolean = false;
   private volume: number = 1.0;
   private isMuted: boolean = false;
@@ -37,6 +38,12 @@ class SoundManager {
     if (!this.isReady) {
       return null;
     }
+    // 同一 key の並行ロードを直列化する。playSound のリトライ経路から再入した際に
+    // player が二重生成されて Map から漏れる（ネイティブリソースのリーク）のを防ぐ。
+    if (this.loading.has(key)) {
+      return this.sounds.get(key) ?? null;
+    }
+    this.loading.add(key);
     try {
       // 同じ key の既存 player があれば破棄してネイティブのオーディオリソースのリークを防ぐ。
       const existing = this.sounds.get(key);
@@ -63,6 +70,8 @@ class SoundManager {
         metadata: { key },
       });
       return null;
+    } finally {
+      this.loading.delete(key);
     }
   }
 
@@ -80,6 +89,9 @@ class SoundManager {
     }
 
     try {
+      // createAudioPlayer はロード非同期のため、初回再生が無音になりうる。isLoaded を
+      // 短時間だけ待ってから再生する（タイムアウト時もベストエフォートで再生）。
+      await this.waitUntilLoaded(player, 400);
       // replayAsync 相当: 先頭へシークしてから再生する。
       await player.seekTo(0);
       player.play();
@@ -107,6 +119,7 @@ class SoundManager {
         this.sounds.delete(key);
         const reloaded = await this.loadSound(key, source);
         if (reloaded) {
+          await this.waitUntilLoaded(reloaded, 400);
           await reloaded.seekTo(0);
           reloaded.play();
         } else {
@@ -125,6 +138,16 @@ class SoundManager {
           metadata: { key, stage: "retry_failed" },
         });
       }
+    }
+  }
+
+  // player.isLoaded を最大 timeoutMs まで待つ。createAudioPlayer のロードは
+  // バックグラウンド進行のため、未ロードのまま play すると無音になるのを防ぐ。
+  private async waitUntilLoaded(player: AudioPlayer, timeoutMs: number): Promise<void> {
+    if (player.isLoaded) return;
+    const start = Date.now();
+    while (!player.isLoaded && Date.now() - start < timeoutMs) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
     }
   }
 

--- a/utils/SoundManager.ts
+++ b/utils/SoundManager.ts
@@ -9,7 +9,7 @@ import { reportSilentError } from "./errorReporter";
 class SoundManager {
   private sounds: Map<string, AudioPlayer> = new Map();
   private sources: Map<string, AudioSource> = new Map();
-  private loading: Set<string> = new Set();
+  private loading: Map<string, Promise<AudioPlayer | null>> = new Map();
   private isReady: boolean = false;
   private volume: number = 1.0;
   private isMuted: boolean = false;
@@ -38,12 +38,23 @@ class SoundManager {
     if (!this.isReady) {
       return null;
     }
-    // 同一 key の並行ロードを直列化する。playSound のリトライ経路から再入した際に
-    // player が二重生成されて Map から漏れる（ネイティブリソースのリーク）のを防ぐ。
-    if (this.loading.has(key)) {
-      return this.sounds.get(key) ?? null;
+    // 同一 key の並行ロードは先行の Promise を共有して直列化する。Set による簡易ロックだと
+    // 先行ロードが this.sounds へ登録される前に後続が呼ばれた場合に null を返してしまい、
+    // 後続の再生が無音になる。Promise 共有なら後続も同じ player を受け取れる。
+    const inflight = this.loading.get(key);
+    if (inflight) {
+      return inflight;
     }
-    this.loading.add(key);
+    const promise = this.createAndRegister(key, source);
+    this.loading.set(key, promise);
+    try {
+      return await promise;
+    } finally {
+      this.loading.delete(key);
+    }
+  }
+
+  private async createAndRegister(key: string, source: AudioSource): Promise<AudioPlayer | null> {
     try {
       // 同じ key の既存 player があれば破棄してネイティブのオーディオリソースのリークを防ぐ。
       const existing = this.sounds.get(key);
@@ -55,7 +66,7 @@ class SoundManager {
         }
       }
       // createAudioPlayer は同期。expo-av の createAsync のような {sound,status} は返さず、
-      // ロードはバックグラウンドで進むため「生成成功＝登録」とする（isLoaded ゲートは設けない）。
+      // ロードはバックグラウンドで進む。playSound 側で isLoaded を待ってから再生する。
       const player = createAudioPlayer(source);
       player.volume = this.volume;
       player.muted = this.isMuted;
@@ -70,8 +81,6 @@ class SoundManager {
         metadata: { key },
       });
       return null;
-    } finally {
-      this.loading.delete(key);
     }
   }
 
@@ -144,9 +153,18 @@ class SoundManager {
   // player.isLoaded を最大 timeoutMs まで待つ。createAudioPlayer のロードは
   // バックグラウンド進行のため、未ロードのまま play すると無音になるのを防ぐ。
   private async waitUntilLoaded(player: AudioPlayer, timeoutMs: number): Promise<void> {
-    if (player.isLoaded) return;
+    // unloadAll 等で player が破棄(remove)されると isLoaded アクセスが例外を投げうる。
+    // 例外時は「これ以上待つ意味がない」とみなして即座に抜ける。
+    const loaded = () => {
+      try {
+        return player.isLoaded;
+      } catch {
+        return true;
+      }
+    };
+    if (loaded()) return;
     const start = Date.now();
-    while (!player.isLoaded && Date.now() - start < timeoutMs) {
+    while (!loaded() && Date.now() - start < timeoutMs) {
       await new Promise((resolve) => setTimeout(resolve, 25));
     }
   }


### PR DESCRIPTION
## Summary
Claude が River Reviewer の skill 観点（logic-torturing 等）を適用したレビュー（**OPENAI/GOOGLE キー不要**のケース）で検出した findings を修正。

### major
- **SoundManager 初回無音**: `createAudioPlayer` はロード非同期のため初回 `playSound` が無音になりうる。expo-audio の `isLoaded`（公式 API、context7 確認済み）を最大400ms待つ `waitUntilLoaded` を追加。
- **SoundManager async競合**: `playSound` リトライからの `loadSound` 再入による player 二重生成・リーク懸念に対し、`loading` フラグで同一 key のロードを直列化（防御的）。

### minor
- **MotionView 再アニメ安定化**: 再アニメ判定キー `animKey` の `JSON.stringify` がキー順序依存。`stableStringify`（キー順正規化）に置換し、`animate`/`from` 動的生成時の過剰再アニメを防ぐ。

## Test plan
- [x] tsc(TS6) / lint / test(45 suites 311) green（回帰なし）
- [x] expo-audio `isLoaded` の存在を context7 で確認（推測実装を排除）
- waitUntilLoaded の正常系は既存 `plays a sound`（mock `isLoaded:true`）でカバー。未ロード待機の実機挙動は EAS ビルドで確認予定。

## レビュー手法
River Reviewer CLI は LLM キー必須（heuristic はほぼ全スキル skip）のため、**River の skill 定義（観点・ゲート・出力形式）を Claude が適用**してレビュー（キー不要）。logic-torturing で major 2件 + minor 1件を検出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)