### PR TITLE
docs: docs を現状に最新化（SDK56 / token 移動 / Closed testing 12人）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ on:
       - "app.config.ts"
       - "eas.json"
       - "design-system/**"
+      - "docs/**"
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [main, develop]
@@ -54,6 +55,7 @@ on:
       - "app.config.ts"
       - "eas.json"
       - "design-system/**"
+      - "docs/**"
   workflow_dispatch:
 
 concurrency:

--- a/docs/design-system/design-tokens.md
+++ b/docs/design-system/design-tokens.md
@@ -1,6 +1,6 @@
 # Design Tokens Specification
 
-`docs/design-system/tokens/*.json` を Digital Omikuji UI の唯一の設計 SSOT とし、React Native / NativeWind 実装はその投影先として扱います。
+`design-system/tokens/*.json` を Digital Omikuji UI の唯一の設計 SSOT とし、React Native / NativeWind 実装はその投影先として扱います。
 
 ## レイヤ構造
 
@@ -26,7 +26,7 @@
 
 ## 更新手順
 
-1. `docs/design-system/tokens/*.json` を更新する
+1. `design-system/tokens/*.json` を更新する
 2. `docs/design-system/component-map.json` と関連 docs を追従させる
 3. 実装側の DS アダプタと UI を追従させる
 4. `pnpm exec tsc --noEmit`

--- a/docs/design-system/operation-guide.md
+++ b/docs/design-system/operation-guide.md
@@ -1,12 +1,12 @@
 # Design System Operation Guide
 
-Digital Omikuji の UI を破壊的変更込みで進化させるための runbook です。一次情報は `docs/design-system/tokens/*.json` と `docs/design-system/component-map.json` です。
+Digital Omikuji の UI を破壊的変更込みで進化させるための runbook です。一次情報は `design-system/tokens/*.json` と `docs/design-system/component-map.json` です。
 
 ## 変更単位ごとの手順
 
 ### Token を追加・変更する
 
-1. `docs/design-system/tokens/primitive.json` / `semantic.json` / `component.json` を更新する
+1. `design-system/tokens/primitive.json` / `semantic.json` / `component.json` を更新する
 2. 実装側の DS アダプタと利用コンポーネントを更新する
 3. `docs/design-system/design-tokens.md` と必要なら `component-map.json` を追従する
 4. `pnpm exec tsc --noEmit`

--- a/docs/design/design_guidelines.md
+++ b/docs/design/design_guidelines.md
@@ -16,7 +16,7 @@
 
 ## 2. カラーパレット (Color Palette)
 
-以下は現行 UI から読み取れる代表的な参考クラスです。正本の token 定義は `docs/design-system/tokens/*.json` を参照してください。
+以下は現行 UI から読み取れる代表的な参考クラスです。正本の token 定義は `design-system/tokens/*.json` を参照してください。
 
 | 用途 | クラス | 色味 | 備考 |
 | --- | --- | --- | --- |

--- a/docs/goals/android-release-readiness.md
+++ b/docs/goals/android-release-readiness.md
@@ -27,7 +27,7 @@ Android版デジタルおみくじを **Google Play に申請可能な状態** �
 - [x] Google Play Console 申請に必要な情報が docs 化されている（[../project/google-play-submission.md](../project/google-play-submission.md)、2026-06-07）
 - [x] Privacy Policy / Data safety / Content rating の方針が整理されている（Sentry 有効前提の Data safety 申告、全年齢レーティング方針、2026-06-07）
 - [x] ストア掲載文・スクリーンショット・Feature Graphic の準備項目が整理されている（画像アセットは未作成だが要件・推奨カットを docs 化、2026-06-07）
-- [x] Closed testing の進め方が整理されている（internal→closed(20人×14日)→production、2026-06-07）
+- [x] Closed testing の進め方が整理されている（internal→closed(個人=12人×14日 / 組織=免除)→production、2026-06-07）
 - [x] README に Android 公開準備手順が反映されている（2026-06-06）
 
 ### 品質ゲート（すべて成功）
@@ -95,12 +95,11 @@ Android版デジタルおみくじを **Google Play に申請可能な状態** �
 - `expo-linking`（`expo-router` の必須 peer）が未インストールだった。Expo Go 外（=本番Androidビルド）でクラッシュし得るため、`npx expo install expo-linking`（`~8.0.12`）で追加。
 - 検証: `tsc` ✅ / `lint` ✅ / `test` 312件 ✅。
 
-#### #4 Expo SDK 54 想定とのバージョン不一致 ✅ 対応済み（(b)採用、2026-06-06）
+#### #4 Expo SDK 54 想定とのバージョン不一致 ✅ 解決済み（最終的に (c) SDK56 へ移行、#443・2026-06-08）
 
-**方針 (b) を採用**: 現状の先行構成を維持し、`package.json` の `expo.install.exclude` に該当20パッケージを登録して expo-doctor を **18/18（No issues）** に。
-これは「RN 0.85 等コア依存を SDK54 上で意図的に運用する」ことの明示宣言であり、**EAS本番ビルドでの最終的な native 互換性検証は production AAB ビルド（ブロッカー3）で行う**。
+**最終対応**: 当初は方針 (b)（SDK54 上で RN0.85 を `package.json` の `expo.install.exclude` で運用）を採用したが、EAS 本番ビルドで RN0.85 の codegen 非互換が顕在化したため、**最終的に Expo SDK56（RN 0.85 を正式サポート）へアップグレード**（#443）して根本解決した。`expo.install.exclude`（20パッケージ）は不要になり削除済み、expo-doctor も整合し production AAB の生成に成功している。
 
-> 参考: patch 落ち（installed が想定よりわずかに古い `expo` / `expo-router` 等）は、将来 `npx expo install --check` で SDK54 pin へ揃える選択肢もある。
+> 当初方針 (b) の記録は以下の `<details>` に経緯参照用として残す。
 
 <details><summary>当初の不一致（参考）</summary>
 

--- a/docs/project/google-play-submission.md
+++ b/docs/project/google-play-submission.md
@@ -89,15 +89,19 @@ IARC 質問票への回答方針:
 ## 5. 署名 / target API level
 
 - **署名**: Google Play App Signing を利用（推奨）。EAS が upload key を管理し、`eas build` が署名済み AAB を生成。Play Console 側で App Signing を有効化。
-- **target API level**: Google Play は新規アプリに targetSdkVersion 35（Android 15）以上を要求（2025年要件）。Expo SDK54 は targetSdk 35 相当 → 充足見込み。AAB アップロード時に警告が無いことを確認。
+- **target API level**: Google Play は新規アプリに targetSdkVersion 35（Android 15）以上を要求（2025年要件）。Expo SDK56（RN 0.85）は targetSdk 35 以上 → 充足。AAB アップロード時に警告が無いことを確認。
 - **versionCode / versionName**: `eas.json` の production は `autoIncrement: true`（versionCode 自動採番）、`appVersionSource: "remote"`（EAS 側で管理）。versionName は `app.json` の `version`。
 
 ## 6. Closed testing の進め方
 
-> Google Play の新規デベロッパー（個人）アカウント（2023-11-13 以降に作成）は、**Production 申請前に Closed testing が必須**（テスター **20人以上** が **14日間連続**でオプトイン）。20人未満では Production access に進めない。
+> Google Play の Closed testing 要件はアカウント種別で異なる（2026 時点）。
+>
+> - **個人アカウント**（2023-11-13 以降作成）: **Production 申請前に Closed testing が必須**。テスター **12人以上**（2024-12-11 に 20→12 へ緩和）が **14日間連続**でオプトイン・**定期利用**する必要がある。条件未達では Production access に進めない。
+> - **組織アカウント**（法人登記 + DUNS 番号で認証）: 本要件は**免除**（テスト不要で Production 申請可）。
+> - **2026 の厳格化**: 単なるオプトインでは不十分で、各テスターが 14 日間「定期的にアプリを開く」必要がある（User Engagement Time を測定し、不活性テスターは除外）。
 
 1. **Internal testing**: AAB を internal track にアップロード（`eas.json` の submit.production.android.track = `internal`）。自分・少人数で動作確認。
-2. **Closed testing**: テスター（**20人以上**）を招待し、**14日間連続**でオプトイン・利用してもらう。フィードバック収集。
+2. **Closed testing**（個人アカウントのみ必須／組織は免除）: テスター（**12人以上**）を招待し、**14日間連続**でオプトイン・**定期利用**してもらう。フィードバック収集。
 3. **Production access 申請**: 上記を満たすと production 申請が可能になる。
 4. 申請内容: Data safety / Content rating / ストア掲載 / 対象国・年齢 を入力し審査提出。
 
@@ -117,5 +121,5 @@ EAS 認証が必要なため、以下のいずれかで実行（詳細は goal d
 - [ ] スクリーンショット2枚以上 + Feature Graphic を作成・アップロード
 - [ ] アプリアイコン 512×512 をアップロード
 - [ ] Privacy Policy URL を設定
-- [ ] internal → closed testing（20人×14日）→ production access
+- [ ] internal → closed testing（個人=12人×14日連続・定期利用 / 組織=免除）→ production access
 - [ ] ストア文に Sentry 診断データの注記を反映（本書 §1）

--- a/docs/project/privacy-policy.md
+++ b/docs/project/privacy-policy.md
@@ -110,7 +110,7 @@
 | シェイク検出 | expo-sensors (Accelerometer) | おみくじを引く動作の検出   |
 | データ保存   | AsyncStorage                 | おみくじ履歴のローカル保存 |
 | 振動         | expo-haptics                 | 触覚フィードバック         |
-| 音声         | expo-av                      | 効果音の再生               |
+| 音声         | expo-audio                   | 効果音の再生               |
 | 画像生成     | react-native-view-shot       | シェア用画像の生成         |
 
 ---


### PR DESCRIPTION
## Summary
develop の docs/ が現状（#443 SDK56移行 / #450 Sentry再有効化 / token JSON 移動 / Google Play 要件変更）と乖離していたため最新化。

### 修正内容
| ファイル | 修正 |
|---|---|
| google-play-submission.md | Closed testing **20→12人** + 組織免除 + 2026 厳格化 / target API を SDK56 に |
| android-release-readiness.md | テスター12人 / #4 節を「SDK56移行で解決済み」に |
| design-tokens.md / operation-guide.md / design_guidelines.md | token パス `docs/design-system/tokens/` → `design-system/tokens/`（#443 で移動、**旧パスは不在**） |
| privacy-policy.md | 音声 `expo-av` → `expo-audio` |

## 背景
- **20→12人**: 2024-12-11 に Google が緩和。組織アカウント（法人+DUNS）は免除。2026 は各テスターの定期利用を測定。
- **token パス**: #443 で token JSON を `docs/` 配下から `design-system/tokens/` へ移動（EAS ビルドで require 解決するため）。docs の SSOT 記述が存在しないパスを指していた。

## Test plan
- [x] markdownlint green

🤖 Generated with [Claude Code](https://claude.com/claude-code)